### PR TITLE
Fix to_sym error parsing bootstrap_options

### DIFF
--- a/lib/chef_metal/provisioner/fog_provisioner.rb
+++ b/lib/chef_metal/provisioner/fog_provisioner.rb
@@ -274,7 +274,7 @@ module ChefMetal
       end
 
       def symbolize_keys(options)
-        options.inject({}) { |result,key,value| result[key.to_sym] = value; result }
+        options.inject({}) { |result,(key,value)| result[key.to_sym] = value; result }
       end
 
       def server_for(node)


### PR DESCRIPTION
I just started tinkering with chef-metal and... this is awesome! I hit one strange error, though.

Using this as my machines recipe:

```
with_provisioner_options(
  'bootstrap_options' => {
    image_name: 'Ubuntu 13.10 x64',
    flavor_name: '512MB',
    region_name: 'New York 2'
  }
)

machine 'test1.p4nt5.com' do
  action :create
end
```

results in an exception while it's parsing the `bootstrap_options`:

```
NoMethodError: machine[test1.p4nt5.com] (utilities-metal::machines line 29) had an error: NoMethodError: undefined method `to_sym' for [:image_name, "Ubuntu 13.10 x64"]:Array
/usr/local/Cellar/ruby/2.1.0/lib/ruby/gems/2.1.0/bundler/gems/chef-metal-75df6cc5d586/lib/chef_metal/provisioner/fog_provisioner.rb:278:in `block in symbolize_keys'
```

Looks like the issue is with how the `inject` method works on hashes:

```
irb(main):011:0> {'key' => 'value'}.inject({}) { |result,key,value| {key => value} }
=> {["key", "value"]=>nil}
irb(main):012:0> {'key' => 'value'}.inject({}) { |result,(key,value)| {key => value} }
=> {"key"=>"value"}
```
