### PR TITLE
Added new private_ip compute_options attribute.

### DIFF
--- a/lib/chef_metal/provisioner/fog_provisioner.rb
+++ b/lib/chef_metal/provisioner/fog_provisioner.rb
@@ -393,7 +393,7 @@ module ChefMetal
           options[:prefix] = 'sudo '
         end
         remote_host = nil
-        if compute_options[:private_ip]
+        if compute_options[:use_private_ip_for_ssh]
           remote_host = server.private_ip_address
         else
           remote_host = server.public_ip_address


### PR DESCRIPTION
with_fog(_ec2)_provisioner :private_ip => true

This will enable you to connect to a private ip address instead of
public. This feature adds support for connecting to VPC's that do not
allow remote connections.
