### PR TITLE
Fix timeout for post-instance-creation timeout

### DIFF
--- a/lib/chef_metal/provisioner/fog_provisioner.rb
+++ b/lib/chef_metal/provisioner/fog_provisioner.rb
@@ -185,7 +185,7 @@ module ChefMetal
 
             # If there is some other error, we just wait patiently for SSH
             begin
-              server.wait_for(option_for(node, :ssh_timeout)) { transport.available? }
+              server.wait_for(option_for(node, :start_timeout)) { transport.available? }
             rescue Fog::Errors::TimeoutError
               # Sometimes (on EC2) the machine comes up but gets stuck or has
               # some other problem.  If this is the case, we restart the server


### PR DESCRIPTION
Changing to start_timeout. The parameter is stated in the file as "start_timeout - the time to wait for the instance to start", which is the state the instance is in at that point (starting)
