### PR TITLE
New ohai hints feature allowing the creation hints.

### DIFF
--- a/lib/chef/resource/machine.rb
+++ b/lib/chef/resource/machine.rb
@@ -45,6 +45,10 @@ class Chef::Resource::Machine < Chef::Resource::LWRPBase
   attribute :admin, :kind_of => [TrueClass, FalseClass]
   attribute :validator, :kind_of => [TrueClass, FalseClass]
 
+  # Client Ohai hints, allows machine to enable hints
+  # e.g. ohai_hint 'ec2' => { 'a' => 'b' } creates file ec2.json with json contents { 'a': 'b' }
+  attribute :ohai_hint, :kind_of => Hash
+
   # Allows you to turn convergence off in the :create action by writing "converge false"
   # or force it with "true"
   attribute :converge, :kind_of => [TrueClass, FalseClass]

--- a/lib/chef/resource/machine.rb
+++ b/lib/chef/resource/machine.rb
@@ -47,7 +47,7 @@ class Chef::Resource::Machine < Chef::Resource::LWRPBase
 
   # Client Ohai hints, allows machine to enable hints
   # e.g. ohai_hint 'ec2' => { 'a' => 'b' } creates file ec2.json with json contents { 'a': 'b' }
-  attribute :ohai_hint, :kind_of => Hash
+  attribute :ohai_hints, :kind_of => Hash
 
   # Allows you to turn convergence off in the :create action by writing "converge false"
   # or force it with "true"

--- a/lib/chef_metal/convergence_strategy/precreate_chef_objects.rb
+++ b/lib/chef_metal/convergence_strategy/precreate_chef_objects.rb
@@ -25,7 +25,7 @@ module ChefMetal
         chef_server_url = machine.make_url_available_to_remote(chef_server_url)
 
         #Support for multiple ohai hints, required on some platforms
-        create_ohai_files(provider, machine, machine_resource)
+        create_ohai_files(action_handler, machine, machine_resource)
 
         # Create client.rb and client.pem on machine
         content = client_rb_content(chef_server_url, machine.node['name'])
@@ -107,12 +107,12 @@ module ChefMetal
       end
 
       # Create the ohai file(s)
-      def create_ohai_files(provider, machine, machine_resource)
+      def create_ohai_files(action_handler, machine, machine_resource)
         if machine_resource.ohai_hint
           machine_resource.ohai_hint.each_pair do |hint, data|
             # The location of the ohai hint
             ohai_hint = "/etc/chef/ohai/hints/#{hint}.json"
-            machine.write_file(provider, ohai_hint, data.to_json, :ensure_dir => true)
+            machine.write_file(action_handler, ohai_hint, data.to_json, :ensure_dir => true)
           end
         end
       end

--- a/lib/chef_metal/convergence_strategy/precreate_chef_objects.rb
+++ b/lib/chef_metal/convergence_strategy/precreate_chef_objects.rb
@@ -108,8 +108,8 @@ module ChefMetal
 
       # Create the ohai file(s)
       def create_ohai_files(action_handler, machine, machine_resource)
-        if machine_resource.ohai_hint
-          machine_resource.ohai_hint.each_pair do |hint, data|
+        if machine_resource.ohai_hints
+          machine_resource.ohai_hints.each_pair do |hint, data|
             # The location of the ohai hint
             ohai_hint = "/etc/chef/ohai/hints/#{hint}.json"
             machine.write_file(action_handler, ohai_hint, data.to_json, :ensure_dir => true)

--- a/lib/chef_metal/convergence_strategy/precreate_chef_objects.rb
+++ b/lib/chef_metal/convergence_strategy/precreate_chef_objects.rb
@@ -24,6 +24,9 @@ module ChefMetal
         chef_server_url = machine_resource.chef_server[:chef_server_url]
         chef_server_url = machine.make_url_available_to_remote(chef_server_url)
 
+        #Support for multiple ohai hints, required on some platforms
+        create_ohai_files(provider, machine, machine_resource)
+
         # Create client.rb and client.pem on machine
         content = client_rb_content(chef_server_url, machine.node['name'])
         machine.write_file(action_handler, client_rb_path, content, :ensure_dir => true)
@@ -100,6 +103,17 @@ module ChefMetal
           key
         else
           nil
+        end
+      end
+
+      # Create the ohai file(s)
+      def create_ohai_files(provider, machine, machine_resource)
+        if machine_resource.ohai_hint
+          machine_resource.ohai_hint.each_pair do |hint, data|
+            # The location of the ohai hint
+            ohai_hint = "/etc/chef/ohai/hints/#{hint}.json"
+            machine.write_file(provider, ohai_hint, data.to_json, :ensure_dir => true)
+          end
         end
       end
 

--- a/lib/chef_metal/machine/unix_machine.rb
+++ b/lib/chef_metal/machine/unix_machine.rb
@@ -56,7 +56,7 @@ module ChefMetal
       def create_dir(action_handler, path)
         if !file_exists?(path)
           action_handler.converge_by "create directory #{path} on #{node['name']}" do
-            transport.execute("mkdir #{path}").error!
+            transport.execute("mkdir -p #{path}").error!
           end
         end
       end


### PR DESCRIPTION
Example:
machine "blah" do
  ohai_hint 'ec2' => {}, 'digitalocean' => {}
end
