### PR TITLE
Grant the node's client read+update permissions

### DIFF
--- a/lib/chef_metal/convergence_strategy/precreate_chef_objects.rb
+++ b/lib/chef_metal/convergence_strategy/precreate_chef_objects.rb
@@ -126,7 +126,11 @@ module ChefMetal
             raw_json machine.node
           end
         end
-        grant_client_node_permissions(machine_resource.chef_server, machine.node['name'], ["read", "update"])
+
+        # If using enterprise/hosted chef, fix acls
+        if machine_resource.chef_server[:chef_server_url] =~ /\/+organizations\/.+/
+          grant_client_node_permissions(machine_resource.chef_server, machine.node['name'], ["read", "update"])
+        end
       end
 
       # Grant the client permissions to the node


### PR DESCRIPTION
@jkeiser looking for your input on this.
I found an issue where the node's client is unable to update the node's attributes with the chef server upon client and node creation. The chef server gives full rights to my personal client, but not the node's client. My current workaround is to use the chef server's (AFAICT undocumented) ACL endpoint to grant read and update rights to the node's client.
This approach looks and feels hacky, but it does work for me right now (gotta make deadlines :stuck_out_tongue_closed_eyes: ). What would be the cleaner approach to do this? I'd rather do things the pretty upstream way than carrying this patch forward :wink: 
