### PR TITLE
cookbooks should have their name in metadata

### DIFF
--- a/cookbooks/chef-metal/metadata.rb
+++ b/cookbooks/chef-metal/metadata.rb
@@ -1,1 +1,2 @@
+name    'chef-metal'
 version '0.1.0'

--- a/cookbooks/myapp/metadata.rb
+++ b/cookbooks/myapp/metadata.rb
@@ -1,3 +1,4 @@
+name    'myapp'
 version '0.1.0'
 
 depends 'chef-metal'


### PR DESCRIPTION
It is a community best practice to have the name of cookbooks in the
metadata, rather than relying on automatic naming by the directory
name of the cookbook. This makes it more explicit and plays better
with cookbook dependency resolution tools.
