### PR TITLE
Add a SUPER SIMPLE machine_execute resource

### DIFF
--- a/lib/chef/provider/machine_execute.rb
+++ b/lib/chef/provider/machine_execute.rb
@@ -1,0 +1,27 @@
+require 'chef/provider/lwrp_base'
+require 'cheffish/cheffish_server_api'
+
+class Chef::Provider::MachineExecute < Chef::Provider::LWRPBase
+
+  use_inline_resources
+
+  def whyrun_supported?
+    true
+  end
+
+  def machine
+    @machine ||= begin
+      if new_resource.machine.kind_of?(ChefMetal::Machine)
+        new_resource.machine
+      else
+        # TODO this is inefficient, can we cache or something?
+        node = Cheffish::CheffishServerAPI.new(new_resource.chef_server).get("/nodes/#{new_resource.machine}")
+        new_resource.provisioner.connect_to_machine(node)
+      end
+    end
+  end
+
+  action :run do
+    machine.execute(self, new_resource.command)
+  end
+end

--- a/lib/chef/resource/machine_execute.rb
+++ b/lib/chef/resource/machine_execute.rb
@@ -1,0 +1,23 @@
+require 'chef/resource/lwrp_base'
+require 'chef_metal'
+require 'chef_metal/machine'
+require 'chef_metal/provisioner'
+
+class Chef::Resource::MachineExecute < Chef::Resource::LWRPBase
+  self.resource_name = 'machine_execute'
+
+  def initialize(*args)
+    super
+    @chef_server = Cheffish.enclosing_chef_server
+    @provisioner = ChefMetal.enclosing_provisioner
+  end
+
+  actions :run
+  default_action :run
+
+  attribute :command, :kind_of => String, :name_attribute => true
+  attribute :machine, :kind_of => [String, ChefMetal::Machine]
+
+  attribute :chef_server, :kind_of => Hash
+  attribute :provisioner, :kind_of => ChefMetal::Provisioner
+end

--- a/lib/chef_metal.rb
+++ b/lib/chef_metal.rb
@@ -4,6 +4,8 @@ require 'chef/resource/machine'
 require 'chef/provider/machine'
 require 'chef/resource/machine_file'
 require 'chef/provider/machine_file'
+require 'chef/resource/machine_execute'
+require 'chef/provider/machine_execute'
 
 require 'chef_metal/inline_resource'
 


### PR DESCRIPTION
Ripped off from the `machine_file` resource, works the same way:

```
   machine_execute "works-on-my-laptop" do
      command 'printenv > /tmp/printenv2 ; uname > /tmp/uname'
      machine box1
    end
```
