### PR TITLE
re-raise Net::SCP error when fails to download

### DIFF
--- a/lib/chef_metal/transport/ssh.rb
+++ b/lib/chef_metal/transport/ssh.rb
@@ -154,16 +154,15 @@ module ChefMetal
         channel = Net::SCP.new(session).download(path, local_path)
         begin
           channel.wait
-        rescue Net::SCP::Error
+        rescue Net::SCP::Error => e
+          # re-raise "SCP did not finish successfully" errors
+          raise e unless /did\snot\sfinish/.match(e.message).nil?
+          # otherwise, ignore for now
           nil
-        rescue
-          # This works around https://github.com/net-ssh/net-scp/pull/10 until a new net-scp is merged.
-          begin
-            channel.close
-            channel.wait
-          rescue Net::SCP::Error
-            nil
-          end
+        # ensure the channel is closed when a rescue happens above
+        ensure
+          channel.close
+          channel.wait
         end
       end
 


### PR DESCRIPTION
Current code simply does a "pass" when a SCP error occurs.

This is very confusing in some situations, for example, when using `machine_file` resource, if there is a "permission denied" error, the chef run should error out. Instead, it currently continues along silently, having simply failed to complete the SCP transfer.

With this update, when a Net::SCP::Error occurs and mentions "did not finish" in it's error message (as per Net::SCP 1.2.0 gem), it will re-raise the exception, causing chef run to fail (as desired).

Additionally, `ensure` is used to close the channel, whether or not exception happens. This is cleaner than nesting `rescue` and works whether or no an exception is caught.
