### PR TITLE
Update gem dependencies to use refactored chef_metal_fog

### DIFF
--- a/cookbooks/myapp/recipes/digitalocean.rb
+++ b/cookbooks/myapp/recipes/digitalocean.rb
@@ -1,4 +1,4 @@
-require 'chef_metal/fog'
+require 'chef_metal_fog'
 
 api_key = ENV['DIGITALOCEAN_API_KEY']
 client_id = ENV['DIGITALOCEAN_CLIENT_ID']

--- a/cookbooks/myapp/recipes/openstack.rb
+++ b/cookbooks/myapp/recipes/openstack.rb
@@ -1,8 +1,6 @@
 include_recipe 'chef-metal'
 
-chef_gem 'fog'
-
-require 'chef_metal/fog'
+require 'chef_metal_fog'
 
 openstack_testdir = File.expand_path('~/openstack_test')
 


### PR DESCRIPTION
Update gem dependencies to use refactored chef_metal_fog rather than chef_metal/fog.  
