### PR TITLE
Return machine from action_ready

### DIFF
--- a/lib/chef/provider/machine.rb
+++ b/lib/chef/provider/machine.rb
@@ -25,6 +25,7 @@ class Chef::Provider::Machine < Chef::Provider::LWRPBase
     action_allocate
     machine = current_driver.ready_machine(action_handler, machine_spec, machine_options)
     machine_spec.save(action_handler)
+    machine
   end
 
   action :setup do


### PR DESCRIPTION
machine_spec.save doesn't return machine, and the other actions calling action_ready assumes the action to return machine
