### PR TITLE
machine.current_driver should returns the current driver from the chef_metal run context if it exists otherwise it uses the machine driver url to new one up

### DIFF
--- a/lib/chef/provider/machine.rb
+++ b/lib/chef/provider/machine.rb
@@ -84,9 +84,11 @@ class Chef::Provider::Machine < Chef::Provider::LWRPBase
   end
 
   def current_driver
-    if machine_spec.driver_url
-      run_context.chef_metal.driver_for_url(machine_spec.driver_url)
-    end
+    run_context.chef_metal.current_driver || (
+      if machine_spec.driver_url
+        run_context.chef_metal.driver_for_url(machine_spec.driver_url)
+      end
+    )
   end
 
   attr_reader :machine_spec


### PR DESCRIPTION
As discussed in Issue #62, I have been having issues with duplicate convergances after bootstrapping with chef metal. The second convergance fails with: 

```
ArgumentError: provisioner_cluster[CHEF] (provisioner::chef_server line 6) had an error: ArgumentError: machine[QA1T3NDEVOPSLABCHEF01] (/home/mwrock/.chef/local-mode-cache/cache/cookbooks/provisioner/providers/cluster.rb line 30) had an error: ArgumentError: Missing required arguments: vsphere_username, vsphere_password
```

The first convergance is invoked from the machine_batch which uses the config vlaues stached in the run context via:

```
  with_vsphere_driver :vsphere_server => hypervisor['vsphere_server'],
    :vsphere_username => hypervisor['vsphere_username'],
    :vsphere_password => hypervisor['vsphere_password'],
    :vsphere_expected_pubkey_hash => hypervisor['vsphere_expected_pubkey_hash'],
    :ssh_password => node['provisioner']['ssh_password']
```

but the second run invoked by the Machine resource calls:

```
run_context.chef_metal.driver_for_url(machine_spec.driver_url)
```

to get the driver and thus my driver options are lost since they are not in the client config.

While the deeper issue is why I see duplicate convergances, it seems like calls to machine.current_driver should reuse the driver in the runcontext.
