### PR TITLE
fixing ssl verify mode value from none to verify_none

### DIFF
--- a/lib/chef_metal/convergence_strategy/precreate_chef_objects.rb
+++ b/lib/chef_metal/convergence_strategy/precreate_chef_objects.rb
@@ -173,7 +173,7 @@ module ChefMetal
 chef_server_url #{chef_server_url.inspect}
 node_name #{node_name.inspect}
 client_key #{convergence_options[:client_pem_path].inspect}
-ssl_verify_mode :none
+ssl_verify_mode :verify_none
 EOM
       end
     end


### PR DESCRIPTION
After updating to latest bits. I'm getting:

```
OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed
```

this fix removes the error.
