### PR TITLE
ssh authentication and host key errors are unrecoverable

### DIFF
--- a/lib/chef_metal/transport/ssh.rb
+++ b/lib/chef_metal/transport/ssh.rb
@@ -138,10 +138,10 @@ module ChefMetal
         Chef::Log.debug("#{username}@#{host} unavailable: network connection failed or broke: #{$!.inspect}")
         disconnect
         false
-      rescue Net::SSH::AuthenticationFailed, Net::SSH::HostKeyMismatch
+      rescue Net::SSH::AuthenticationFailed, Net::SSH::HostKeyMismatch => e
         Chef::Log.debug("#{username}@#{host} unavailable: SSH authentication error: #{$!.inspect} ")
         disconnect
-        false
+        raise e
       end
 
       protected


### PR DESCRIPTION
Perhaps this should re-raise because the transport can never become available in this condition.

<!---
@huboard:{"milestone_order":94.0}
-->
