### PR TITLE
Fixing windows convergence via winrm

### DIFF
--- a/chef-metal.gemspec
+++ b/chef-metal.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'net-ssh-gateway', '~> 1.2.0'
   s.add_dependency 'inifile', '~> 2.0'
   s.add_dependency 'cheffish', '~> 0.5'
+  s.add_dependency 'winrm', '~> 1.1.3'  
 #  s.add_dependency 'ruby-lxc'
 
   s.add_development_dependency 'rspec'

--- a/lib/chef_metal/convergence_strategy/install_msi.rb
+++ b/lib/chef_metal/convergence_strategy/install_msi.rb
@@ -9,7 +9,7 @@ module ChefMetal
       def initialize(convergence_options, config)
         super
         @install_msi_url = convergence_options[:install_msi_url] || 'http://www.opscode.com/chef/install.msi'
-        @install_msi_path = convergence_options[:install_msi_path] || "%TEMP%\\#{File.basename(@install_msi_url)}"
+        @install_msi_path = convergence_options[:install_msi_path] || "$env:TEMP\\#{File.basename(@install_msi_url)}"
         @chef_client_timeout = convergence_options.has_key?(:chef_client_timeout) ? convergence_options[:chef_client_timeout] : 120*60 # Default: 2 hours
       end
 


### PR DESCRIPTION
adding fixes for winrm: 1.)- adding winrm to gemspec, 2.) Correct install_msi_path to be powershell friendly, 3.) adding available and make_url_available_to_remote methods to winrm (make_url_available_to_remote is a noop since winrm cannot forward port, 4.)adding reader attribute for config
