### PR TITLE
merge current_machine_options into config in connect_to_machine

### DIFF
--- a/lib/chef_metal/chef_run_data.rb
+++ b/lib/chef_metal/chef_run_data.rb
@@ -63,7 +63,16 @@ module ChefMetal
       else
         machine_spec = ChefMetal::ChefMachineSpec.get(name, chef_server)
       end
-      ChefMetal.connect_to_machine(machine_spec, config)
+
+      merged_config = begin
+        if current_machine_options
+          Cheffish::MergedConfig.new({ :machine_options => current_machine_options }, config)
+        else
+          config
+        end
+      end
+
+      ChefMetal.connect_to_machine(machine_spec, merged_config)
     end
 
     private


### PR DESCRIPTION
I'm not sure if this is the right thing to do.

In testing the machine_file resource with chef_metal_vsphere 0.3.0.beta.1, the config parameter passed to the driver's connect_to_machine does not contain a machine_options hash.  Without the machine_options, I'm not sure where to obtain ssh_config for the machine.

#am_i_doing_it_right


<!---
@huboard:{"milestone_order":98.0}
-->
