### PR TITLE
include bootstrap_proxy key into convergence_options

### DIFF
--- a/lib/chef_metal/convergence_strategy/install_sh.rb
+++ b/lib/chef_metal/convergence_strategy/install_sh.rb
@@ -14,12 +14,13 @@ module ChefMetal
         super(convergence_options, config)
         @install_sh_url = convergence_options[:install_sh_url] || 'http://www.opscode.com/chef/install.sh'
         @install_sh_path = convergence_options[:install_sh_path] || '/tmp/chef-install.sh'
-		@bootstrap_env = convergence_options[:bootstrap_proxy] ? "http_proxy=#{convergence_options[:bootstrap_proxy]}" : ""
+        @bootstrap_env = convergence_options[:bootstrap_proxy] ? "http_proxy=#{convergence_options[:bootstrap_proxy]}" : ""
         @chef_client_timeout = convergence_options.has_key?(:chef_client_timeout) ? convergence_options[:chef_client_timeout] : 120*60 # Default: 2 hours
       end
 
       attr_reader :install_sh_url
       attr_reader :install_sh_path
+      attr_reader :bootstrap_env
 
       def setup_convergence(action_handler, machine)
         super


### PR DESCRIPTION
This change adds the corresponding environment variable to the remote execute call for chef-install.sh, if machine_options => { :convergence_options => { :bootstrap_proxy => '<proxy URL>' }} is set in the recipe. 
