### PR TITLE
Get machine images working with multiple machines

### DIFF
--- a/docs/examples/ec2_images.rb
+++ b/docs/examples/ec2_images.rb
@@ -1,0 +1,11 @@
+require 'chef_metal'
+
+machine_image 'foo'
+
+machine 'quiddle' do
+  from_image 'foo'
+end
+
+machine 'baz' do
+  from_image 'foo'
+end

--- a/lib/chef/provider/machine.rb
+++ b/lib/chef/provider/machine.rb
@@ -105,24 +105,20 @@ class Chef::Provider::Machine < Chef::Provider::LWRPBase
   end
 
   def new_machine_options
-    # TODO current_machine_options
-    if from_image_spec && from_image_spec.machine_options
-      machine_options(new_driver, from_image_spec.machine_options)
-    else
-      machine_options(new_driver)
-    end
+    machine_options(new_driver)
   end
 
   def current_machine_options
-    if from_image_spec && from_image_spec.machine_options
-      machine_options(new_driver, from_image_spec.machine_options)
-    else
-      machine_options(current_driver)
-    end
+    machine_options(current_driver)
   end
 
-  def machine_options(driver, *more_configs)
-    configs = more_configs
+  def machine_options(driver)
+    configs = []
+
+    if from_image_spec && from_image_spec.machine_options
+      configs << from_image_spec.machine_options
+    end
+
     configs << {
       :convergence_options =>
         [ :chef_server,


### PR DESCRIPTION
Relocated the image_spec machine options loading for all machine_options calls - this is needed for batch machine support as seen in the example ec2_images.rb
