### PR TITLE
pass timeout from execution_options to winrm set_timeout

### DIFF
--- a/lib/chef_metal/transport/winrm.rb
+++ b/lib/chef_metal/transport/winrm.rb
@@ -19,6 +19,7 @@ module ChefMetal
 
       def execute(command, execute_options = {})
         output = with_execute_timeout(execute_options) do
+          session.set_timeout(execute_timeout(execute_options))
           session.run_powershell_script(command) do |stdout, stderr|
             stream_chunk(execute_options, stdout, stderr)
           end


### PR DESCRIPTION
the winrm gem uses a default 60 second operation timeout on all winrm web service calls. This can be adjusted using the `set_timeout` method. So if a winrm operation takes longer than a minute, it will timeout regardless of the timeout that chef metal is using at the ruby level which defaults to 15 minutes. This ensures that the timeout that chef-metal uses for `with_execution_timeout` is passed on to the winrm `set_timeout` method.
