### PR TITLE
do not verify ssl because we only use http

### DIFF
--- a/lib/chef_metal/convergence_strategy/precreate_chef_objects.rb
+++ b/lib/chef_metal/convergence_strategy/precreate_chef_objects.rb
@@ -173,7 +173,7 @@ module ChefMetal
 chef_server_url #{chef_server_url.inspect}
 node_name #{node_name.inspect}
 client_key #{convergence_options[:client_pem_path].inspect}
-ssl_verify_mode :verify_none
+ssl_verify_mode :verify_peer
 EOM
       end
     end


### PR DESCRIPTION
This will remove the extraneous output in the metal convergences since we don't use SSL,
but connect to an SSH forwarded port on localhost.
