### PR TITLE
Create chef-metal.rb

### DIFF
--- a/lib/chef-metal.rb
+++ b/lib/chef-metal.rb
@@ -1,0 +1,1 @@
+require 'chef_metal'


### PR DESCRIPTION
Allow users to

```
require 'chef-metal'
```

so that the normal case of requiring the gem name works. Leaving chef_metal.rb as-is so that no existing code-bases are broken.
