### PR TITLE
set ssl_verify_mode dynamically based on chef server url

### DIFF
--- a/lib/chef_metal/convergence_strategy/precreate_chef_objects.rb
+++ b/lib/chef_metal/convergence_strategy/precreate_chef_objects.rb
@@ -169,11 +169,17 @@ module ChefMetal
       end
 
       def client_rb_content(chef_server_url, node_name)
+        if chef_server_url.downcase.start_with?("https")
+          ssl_verify_mode = ':verify_none'
+        else
+          ssl_verify_mode = ':verify_peer'
+        end
+
         <<EOM
 chef_server_url #{chef_server_url.inspect}
 node_name #{node_name.inspect}
 client_key #{convergence_options[:client_pem_path].inspect}
-ssl_verify_mode :verify_peer
+ssl_verify_mode #{ssl_verify_mode}
 EOM
       end
     end


### PR DESCRIPTION
Ran into issues with https://github.com/opscode/chef-metal/pull/164 when provisioning servers against a chef server (not local mode) on https. This will set `ssl_verify_mode` to `:verify_none` for `https` server urls and `:verify_peer` for `http` based addresses.
