### PR TITLE
Flip logic on ssl peer validation

### DIFF
--- a/lib/chef/provisioning/convergence_strategy/precreate_chef_objects.rb
+++ b/lib/chef/provisioning/convergence_strategy/precreate_chef_objects.rb
@@ -171,9 +171,9 @@ module Provisioning
 
       def client_rb_content(chef_server_url, node_name)
         if chef_server_url.downcase.start_with?("https")
-          ssl_verify_mode = ':verify_none'
-        else
           ssl_verify_mode = ':verify_peer'
+        else
+          ssl_verify_mode = ':verify_none'
         end
 
         <<EOM


### PR DESCRIPTION
Flipping logic on whether :verify_peer is written, we only should be doing this on https
