### PR TITLE
When fetching Chef installer metadata, clean up newlines in the output

### DIFF
--- a/lib/chef/provisioning/convergence_strategy/install_cached.rb
+++ b/lib/chef/provisioning/convergence_strategy/install_cached.rb
@@ -124,7 +124,7 @@ module Provisioning
         metadata = {}
         metadata_str.each_line do |line|
           key, value = line.split("\t", 2)
-          metadata[key] = value
+          metadata[key] = value.chomp
         end
         metadata
       end


### PR DESCRIPTION
Fixes issue #206

Installing Chef always failed because of newlines in the metadata output.
