### PR TITLE
Destroy action to the image provider.

### DIFF
--- a/lib/chef/provider/machine_image.rb
+++ b/lib/chef/provider/machine_image.rb
@@ -36,6 +36,14 @@ class MachineImage < Chef::Provider::LWRPBase
   end
 
   action :destroy do
+    # Get the image mapping on the server (from name to image-id)
+    image_spec = Chef::Provisioning::ChefImageSpec.get(new_resource.name, new_resource.chef_server) ||
+        Chef::Provisioning::ChefImageSpec.empty(new_resource.name, new_resource.chef_server)
+
+    if image_spec.location
+      new_driver.destroy_image(action_handler, image_spec, new_resource.image_options)
+      image_spec.delete(action_handler)
+    end
   end
 
   def create_image(image_spec)

--- a/lib/chef/provisioning/chef_image_spec.rb
+++ b/lib/chef/provisioning/chef_image_spec.rb
@@ -15,7 +15,7 @@ module Provisioning
     end
 
     #
-    # Get a ImageSpec from the chef server.  If the node does not exist on the
+    # Get a ImageSpec from the chef server.  If the image does not exist on the
     # server, it returns nil.
     #
     def self.get(name, chef_server = Cheffish.default_chef_server)
@@ -51,12 +51,12 @@ module Provisioning
     end
 
     #
-    # Save this node to the server.  If you have significant information that
+    # Save this image to the server.  If you have significant information that
     # could be lost, you should do this as quickly as possible.  Data will be
     # saved automatically for you after allocate_image and ready_image.
     #
     def save(action_handler)
-      # Save the node to the server.
+      # Save the image to the server.
       _self = self
       _chef_server = _self.chef_server
       Chef::Provisioning.inline_resource(action_handler) do
@@ -72,14 +72,14 @@ module Provisioning
     end
 
     def delete(action_handler)
-      # Save the node to the server.
+      # Delete the image from the server.
       _self = self
       _chef_server = _self.chef_server
       Chef::Provisioning.inline_resource(action_handler) do
         chef_data_bag_item _self.name do
           data_bag 'images'
           chef_server _chef_server
-          action :destroy
+          action :delete
         end
       end
     end


### PR DESCRIPTION
Fixed the chef_data_bag_item action in the delete method in
ChefImageSpec from :destroy to :delete and updated a bunch of comments
in the class.
