### PR TITLE
Fix ssh_gateway values without a username in them

### DIFF
--- a/lib/chef/provisioning/transport/ssh.rb
+++ b/lib/chef/provisioning/transport/ssh.rb
@@ -280,8 +280,10 @@ module Provisioning
 
       def gateway
         gw_user, gw_host = options[:ssh_gateway].split('@')
+        # If we didn't have an '@' in the above, then the value is actually
+        # the hostname, not the username.
+        gw_host, gw_user = gw_user, gw_host if gw_host.nil?
         gw_host, gw_port = gw_host.split(':')
-        gw_user = ssh_options[:ssh_username] unless gw_user
 
         ssh_start_opts = { timeout:10 }.merge(ssh_options)
         ssh_start_opts[:port] = gw_port || 22

--- a/lib/chef/provisioning/transport/ssh.rb
+++ b/lib/chef/provisioning/transport/ssh.rb
@@ -24,7 +24,9 @@ module Provisioning
       #   - :ssh_pty_enable: set to false to disable pty (some instances don't
       #     support this, most do)
       #   - :ssh_gateway: the gateway to use, e.g. "jkeiser@145.14.51.45:222".
-      #     nil (the default) means no gateway.
+      #     nil (the default) means no gateway. If the username is omitted,
+      #     then the default username is used instead (i.e. the user running
+      #     chef, or the username configured in .ssh/config).
       # - global_config: an options hash that looks suspiciously similar to
       #   Chef::Config, containing at least the key :log_level.
       #


### PR DESCRIPTION
This change fixes the behavior when an ssh_gateway is given that is simply a
hostname and doesn't include a username.

Previously, ssh_gateway values without an @ in them would result in the
hostname value being stored in gw_user and gw_host being nil, causing an
exception on the next line.

In addition, the line that sets a default username for the gateway to the same
as for the machine itself has been removed. This code never took effect anyway
due to the previous bug and it makes an incorrect assumption that the username
on the new machine is the same as the username on the gateway machine, which
is almost never the case given that the username on the new machine is
something like root, ec2user or ubuntu when creating a machine.