### PR TITLE
Allow overriding ssl_verify_mode via convergence_options

### DIFF
--- a/lib/chef/provisioning/convergence_strategy/precreate_chef_objects.rb
+++ b/lib/chef/provisioning/convergence_strategy/precreate_chef_objects.rb
@@ -176,6 +176,10 @@ module Provisioning
           ssl_verify_mode = ':verify_none'
         end
 
+        unless convergence_options[:ssl_verify_mode].nil?
+          ssl_verify_mode = convergence_options[:ssl_verify_mode].to_sym.inspect
+        end
+
         <<EOM
 chef_server_url #{chef_server_url.inspect}
 node_name #{node_name.inspect}


### PR DESCRIPTION
This lets someone change ssl_verify_mode in client.rb if they need to.