### PR TITLE
allow configurable log_level in msi install

### DIFF
--- a/lib/chef/provisioning/convergence_strategy/install_msi.rb
+++ b/lib/chef/provisioning/convergence_strategy/install_msi.rb
@@ -42,10 +42,11 @@ module Provisioning
       def converge(action_handler, machine)
         super
 
-        # TODO For some reason I get a 500 back if I don't do -l debug
         action_handler.open_stream(machine.node['name']) do |stdout|
           action_handler.open_stream(machine.node['name']) do |stderr|
-            machine.execute(action_handler, "chef-client -l debug",
+            command_line = "chef-client"
+            command_line << " -l #{config[:log_level].to_s}" if config[:log_level]
+            machine.execute(action_handler, command_line,
               :stream_stdout => stdout,
               :stream_stderr => stderr,
               :timeout => @chef_client_timeout)


### PR DESCRIPTION
- mimic the install_sh convergence strategy to allow a configurable log level, cut the noise from `-l debug`