### PR TITLE
replace some getchefs with chef.ios; fix some copyright notices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,7 +194,7 @@
 
 ## 0.8 (4/8/2014)
 
-- New machine_execute resource! (irving@getchef.com)
+- New machine_execute resource! (irving@chef.io)
 - Experimental "metal" command line: metal execute NODENAME COMMAND ARGS
 - Transport: Add ability to stream execute() for better nested chef-client debugging
 
@@ -209,14 +209,14 @@
 
 ## 0.5 (4/3/2014)
 
-* Provisioner interface changes designed to allow provisioners to be used outside of Chef (doubt@getchef.com)
+* Provisioner interface changes designed to allow provisioners to be used outside of Chef (doubt@chef.io)
   * All Provisioner and Machine methods now take "action_handler" instead of "driver."  It uses the ActionHandler interface described in action_handler.rb.  In short:
     - driver.run_context -> action_handler.recipe_context
     - driver.updated_by_last_action(true) -> action_handler.updated!
     - driver.converge_by -> action_handler.perform_action
     - driver.cookbook_name -> driver.debug_name
   * Convergence strategy: delete_chef_objects() -> cleanup_convergence()
-* Ability to get back to a machine from a node (another Provisioner interface change) (doubt@getchef.com):
+* Ability to get back to a machine from a node (another Provisioner interface change) (doubt@chef.io):
   * Provisioners must create a file named `chef_provisioning/provisioner_init/<scheme>_init.rb`.  It will be required when a node is encountered with that scheme.  It should call Chef::Provisioning.add_registered_provisioner_class(<scheme>, <provisioner class name>).  For the provisioner_url `fog:AWS:21348723432`, the scheme is "fog" and the file is `chef_provisioningprovisioner_init/fog_init.rb`.  It should call `Chef::Provisioning.add_registered_provisioner_class('fog', Chef::Provisioning::Provisioner::FogProvisioner)`.
   * Provisioner classes must implement the class method `inflate(node)`, which should create a Provisioner instance appropriate to the given `node` (generally by looking at `node['normal']['provisioner_output']`)
 * New `NoConverge` convergence strategy that creates a node but does not install Chef or converge.

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ Date       | Blog
 -----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------
 6/3/2014   | [machine_batch and parallelization](https://github.com/chef/chef-provisioning/blob/master/docs/blogs/2012-05-28-machine_batch.html.markdown#chef-provisioning-parallelization)
 6/3/2014   | [Chef Provisioning, Configuration and Drivers](https://github.com/chef/chef-provisioning/blob/master/docs/blogs/2012-05-22-new-driver-interface.html.markdown#chef-provisioning-configuration-and-drivers)
-3/4/2014   | [Chef Metal 0.2: Overview](http://www.getchef.io/blog/2014/03/04/chef-metal-0-2-release/) - this is a pretty good overview (though dated).
-12/20/2013 | [Chef Metal Alpha](http://www.getchef.io/blog/2013/12/20/chef-metal-alpha/)
+3/4/2014   | [Chef Metal 0.2: Overview](http://www.chef.io/blog/2014/03/04/chef-metal-0-2-release/) - this is a pretty good overview (though dated).
+12/20/2013 | [Chef Metal Alpha](http://www.chef.io/blog/2013/12/20/chef-metal-alpha/)
 
 Documentation
 -------------
-* [Chef Docs](https://docs.getchef.io/provisioning.html)
+* [Chef Docs](https://docs.chef.io/provisioning.html)
 * [Frequently Asked Questions](https://github.com/chef/chef-provisioning/blob/master/docs/faq.md)
 * [Configuration](https://github.com/chef/chef-provisioning/blob/master/docs/configuration.md#configuring-and-using-provisioning-drivers)
 * [Writing Drivers](https://github.com/chef/chef-provisioning/blob/master/docs/building_drivers.md#writing-drivers)
@@ -260,6 +260,6 @@ Chef Provisioning also works with Test Kitchen, allowing you to test entire clus
 Bugs and The Plan
 -----------------
 
-Please submit bugs, gripes and feature requests at [https://github.com/chef/chef-provisioning/issues](https://twitter.com/jkeiser2), contact jkeiser on Twitter at @jkeiser2, email at [jkeiser@getchef.io](mailto:jkeiser@getchef.io)
+Please submit bugs, gripes and feature requests at [https://github.com/chef/chef-provisioning/issues](https://twitter.com/jkeiser2), contact jkeiser on Twitter at @jkeiser2, email at [jkeiser@chef.io](mailto:jkeiser@chef.io)
 
 To contribute, just make a PR in the appropriate repo--also, make sure you've [signed the Chef Contributor License Agreement](https://supermarket.chef.io/become-a-contributor) (quick couple of minutes online), since this is going into core Chef eventually. It takes some time to process, so if you've just done it, let me know in the PR :)  If you already signed this for a Chef contribution, you don't need to do so again!

--- a/lib/chef/provisioning/action_handler.rb
+++ b/lib/chef/provisioning/action_handler.rb
@@ -1,8 +1,8 @@
 # -*- encoding: utf-8 -*-
 #
-# Author:: Douglas Triggs (<doug@getchef.com>)
+# Author:: Douglas Triggs (<doug@chef.io>)
 #
-# Copyright (C) 2014, Chef, Inc.
+# Copyright (C) 2014, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/chef/provisioning/chef_provider_action_handler.rb
+++ b/lib/chef/provisioning/chef_provider_action_handler.rb
@@ -1,8 +1,8 @@
 # -*- encoding: utf-8 -*-
 #
-# Author:: Douglas Triggs (<doug@getchef.com>)
+# Author:: Douglas Triggs (<doug@chef.io>)
 #
-# Copyright (C) 2014, Chef, Inc.
+# Copyright (C) 2014, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/acceptance/Berksfile
+++ b/test/acceptance/Berksfile
@@ -1,3 +1,3 @@
-source 'https://supermarket.getchef.com'
+source 'https://supermarket.chef.io'
 
 cookbook 'build-essential'


### PR DESCRIPTION
I noticed that some things in the readme had "getchef.io" which wasn't a thing. Grepping came up with a few other instances of things that could be changed so here they are.