### PR TITLE
Preventing machine from recreating keys and config if already converged

### DIFF
--- a/lib/chef/provisioning/convergence_strategy/install_sh.rb
+++ b/lib/chef/provisioning/convergence_strategy/install_sh.rb
@@ -24,10 +24,10 @@ module Provisioning
       attr_reader :bootstrap_env
 
       def setup_convergence(action_handler, machine)
-        super
-
         # Install chef-client.  TODO check and update version if not latest / not desired
         if machine.execute_always('chef-client -v').exitstatus != 0
+          super
+          
           # TODO ssh verification of install.sh before running arbtrary code would be nice?
           @@install_sh_cache[install_sh_url] ||= Net::HTTP.get(URI(install_sh_url))
           machine.write_file(action_handler, install_sh_path, @@install_sh_cache[install_sh_url], :ensure_dir => true)


### PR DESCRIPTION
When I converge a `machine` resource many times with logging on, I see many INFO logs like:

```
[2015-01-30T09:35:38-08:00] INFO: Processing chef_node[tball_test] action create (basic_chef_client::block line 64)
[2015-01-30T09:35:38-08:00] INFO: Executing sudo pwd on ubuntu@54.186.161.222
[2015-01-30T09:35:40-08:00] INFO: Completed pwd on ubuntu@54.186.161.222: exit status 0
[2015-01-30T09:35:40-08:00] INFO: Processing chef_node[tball_test] action create (basic_chef_client::block line 64)
[2015-01-30T09:35:40-08:00] INFO: Executing sudo cp /etc/chef/client.pem /tmp/client.pem.2590553926 on ubuntu@54.186.161.222
[2015-01-30T09:35:42-08:00] INFO: Completed cp /etc/chef/client.pem /tmp/client.pem.2590553926 on ubuntu@54.186.161.222: exit status 0
[2015-01-30T09:35:42-08:00] INFO: Executing sudo chown ubuntu /tmp/client.pem.2590553926 on ubuntu@54.186.161.222
[2015-01-30T09:35:42-08:00] INFO: Completed chown ubuntu /tmp/client.pem.2590553926 on ubuntu@54.186.161.222: exit status 0
[2015-01-30T09:35:42-08:00] INFO: Executing sudo rm /tmp/client.pem.2590553926 on ubuntu@54.186.161.222
[2015-01-30T09:35:42-08:00] INFO: Completed rm /tmp/client.pem.2590553926 on ubuntu@54.186.161.222: exit status 0
[2015-01-30T09:35:42-08:00] INFO: Processing chef_client[tball_test] action create (basic_chef_client::block line 134)
[2015-01-30T09:35:42-08:00] INFO: Processing chef_node[tball_test] action create (basic_chef_client::block line 145)
[2015-01-30T09:35:42-08:00] INFO: Port forwarded: local URL http://localhost:8889 is available to 54.186.161.222 as http://localhost:8889 for the duration of this SSH connection.
[2015-01-30T09:35:42-08:00] INFO: Executing sudo ls -d /etc/chef/ohai/hints/ec2.json on ubuntu@54.186.161.222
[2015-01-30T09:35:42-08:00] INFO: Completed ls -d /etc/chef/ohai/hints/ec2.json on ubuntu@54.186.161.222: exit status 0
[2015-01-30T09:35:42-08:00] INFO: Executing sudo md5sum -b /etc/chef/ohai/hints/ec2.json on ubuntu@54.186.161.222
[2015-01-30T09:35:42-08:00] INFO: Completed md5sum -b /etc/chef/ohai/hints/ec2.json on ubuntu@54.186.161.222: exit status 0
[2015-01-30T09:35:42-08:00] INFO: Executing sudo ls -d /etc/chef/client.rb on ubuntu@54.186.161.222
[2015-01-30T09:35:42-08:00] INFO: Completed ls -d /etc/chef/client.rb on ubuntu@54.186.161.222: exit status 0
[2015-01-30T09:35:42-08:00] INFO: Executing sudo md5sum -b /etc/chef/client.rb on ubuntu@54.186.161.222
[2015-01-30T09:35:42-08:00] INFO: Completed md5sum -b /etc/chef/client.rb on ubuntu@54.186.161.222: exit status 0
[2015-01-30T09:35:42-08:00] INFO: Executing sudo chef-client -v on ubuntu@54.186.161.222
[2015-01-30T09:35:45-08:00] INFO: Completed chef-client -v on ubuntu@54.186.161.222: exit status 0
[2015-01-30T09:35:45-08:00] INFO: Processing chef_node[tball_test] action create (basic_chef_client::block line 64)
 (up to date)
```

This seemed unnecessary to me because the resource is already converged.  Chef has ran successfully once so we do not need manage the /etc/chef/client.pem file anymore.