### PR TITLE
Add show_output attribute for machine_execute.

### DIFF
--- a/lib/chef/provider/machine_execute.rb
+++ b/lib/chef/provider/machine_execute.rb
@@ -27,7 +27,7 @@ class MachineExecute < Chef::Provider::LWRPBase
   end
 
   action :run do
-    machine.execute(action_handler, new_resource.command)
+    machine.execute(action_handler, new_resource.command, :stream => new_resource.show_output)
   end
 
 end

--- a/lib/chef/resource/machine_execute.rb
+++ b/lib/chef/resource/machine_execute.rb
@@ -19,6 +19,7 @@ class MachineExecute < Chef::Resource::LWRPBase
 
   attribute :command, :kind_of => String, :name_attribute => true
   attribute :machine, :kind_of => String
+  attribute :show_output, :kind_of => [TrueClass,FalseClass], :default => false
 
   attribute :chef_server, :kind_of => Hash
   attribute :driver, :kind_of => Chef::Provisioning::Driver


### PR DESCRIPTION
I have a `machine_execute` at the end of my provision recipe that runs system integration tests from a node in the cluster. It's nice to see the output without having to use `-l debug`. I use chef-provisioning as a developer so that my co-workers can provision their own development clusters and it's cool to run the tests at the end automatically.

I suppose a similar effect could be achieved by capturing the output on the remote server and then downloading and displaying it on the provisioning server...