### PR TITLE
Install/Upgrade if the chef-client (or the specified version) does not exist

### DIFF
--- a/lib/chef/provisioning/convergence_strategy/install_cached.rb
+++ b/lib/chef/provisioning/convergence_strategy/install_cached.rb
@@ -42,14 +42,15 @@ module Provisioning
       def setup_convergence(action_handler, machine)
         super
 
-        # Install chef-client.  TODO check and update version if not latest / not desired
-        if machine.execute_always('chef-client -v').exitstatus != 0
-          platform, platform_version, machine_architecture = machine.detect_os(action_handler)
-          package_file = download_package_for_platform(action_handler, machine, platform, platform_version, machine_architecture)
-          remote_package_file = "#{@tmp_dir}/#{File.basename(package_file)}"
-          machine.upload_file(action_handler, package_file, remote_package_file)
-          install_package(action_handler, machine, remote_package_file)
-        end
+        # Install chef-client.
+        version = machine.execute_always('chef-client -v')
+        return if version.exitstatus == 0 and version.stdout().strip().include?(" #{chef_version}")
+
+        platform, platform_version, machine_architecture = machine.detect_os(action_handler)
+        package_file = download_package_for_platform(action_handler, machine, platform, platform_version, machine_architecture)
+        remote_package_file = "#{@tmp_dir}/#{File.basename(package_file)}"
+        machine.upload_file(action_handler, package_file, remote_package_file)
+        install_package(action_handler, machine, remote_package_file)
       end
 
       def converge(action_handler, machine)

--- a/lib/chef/provisioning/convergence_strategy/install_cached.rb
+++ b/lib/chef/provisioning/convergence_strategy/install_cached.rb
@@ -51,7 +51,7 @@ module Provisioning
         if version.exitstatus == 0
           if !chef_version
             return
-          elsif version.stdout.strip =~ /Chef: #{chef_version}([^0-9]|$)/
+          elsif version.stdout.strip =~ /Chef: #{chef_version}$/
             return
           end
         end

--- a/lib/chef/provisioning/convergence_strategy/install_cached.rb
+++ b/lib/chef/provisioning/convergence_strategy/install_cached.rb
@@ -45,10 +45,13 @@ module Provisioning
         # Check for existing chef client.
         version = machine.execute_always('chef-client -v')
 
+        # Don't do install/upgrade if a chef client exists and
+        # no chef version is defined by user configs or
+        # the chef client's version already matches user config
         if version.exitstatus == 0
-          if chef_version and version.stdout.strip =~ /Chef: #{chef_version}([^0-9]|$)/
+          if !chef_version
             return
-          elsif !chef_version
+          elsif version.stdout.strip =~ /Chef: #{chef_version}([^0-9]|$)/
             return
           end
         end

--- a/lib/chef/provisioning/convergence_strategy/install_msi.rb
+++ b/lib/chef/provisioning/convergence_strategy/install_msi.rb
@@ -37,7 +37,7 @@ module Provisioning
         if version.exitstatus == 0
           if !chef_version
             return
-          elsif version.stdout.strip =~ /Chef: #{chef_version}([^0-9]|$)/
+          elsif version.stdout.strip =~ /Chef: #{chef_version}$/
             return
           end
         end

--- a/lib/chef/provisioning/convergence_strategy/install_msi.rb
+++ b/lib/chef/provisioning/convergence_strategy/install_msi.rb
@@ -28,15 +28,16 @@ module Provisioning
 
         super
 
-        # Install chef-client.  TODO check and update version if not latest / not desired
-        if machine.execute_always('chef-client -v').exitstatus != 0
-          # TODO ssh verification of install.msi before running arbtrary code would be nice?
-          # TODO find a way to cache this on the host like with the Unix stuff.
-          # Limiter is we don't know how to efficiently upload large files to
-          # the remote machine with WMI.
-          machine.execute(action_handler, "(New-Object System.Net.WebClient).DownloadFile(#{machine.escape(install_msi_url)}, #{machine.escape(install_msi_path)})")
-          machine.execute(action_handler, "msiexec /qn /i #{machine.escape(install_msi_path)}")
-        end
+        # Install chef-client.
+        version = machine.execute_always('chef-client -v')
+        return if version.exitstatus == 0 and version.stdout().strip().include?(" #{chef_version}")
+
+        # TODO ssh verification of install.msi before running arbtrary code would be nice?
+        # TODO find a way to cache this on the host like with the Unix stuff.
+        # Limiter is we don't know how to efficiently upload large files to
+        # the remote machine with WMI.
+        machine.execute(action_handler, "(New-Object System.Net.WebClient).DownloadFile(#{machine.escape(install_msi_url)}, #{machine.escape(install_msi_path)})")
+        machine.execute(action_handler, "msiexec /qn /i #{machine.escape(install_msi_path)}")
       end
 
       def converge(action_handler, machine)

--- a/lib/chef/provisioning/convergence_strategy/install_msi.rb
+++ b/lib/chef/provisioning/convergence_strategy/install_msi.rb
@@ -28,10 +28,18 @@ module Provisioning
 
         super
 
-        # Install chef-client.
+        # Check for existing chef client.
         version = machine.execute_always('chef-client -v')
-        return if version.exitstatus == 0 and version.stdout().strip().include?(" #{chef_version}")
 
+        if version.exitstatus == 0
+          if chef_version and version.stdout.strip =~ /Chef: #{chef_version}([^0-9]|$)/
+            return
+          elsif !chef_version
+            return
+          end
+        end
+
+        # Install chef client
         # TODO ssh verification of install.msi before running arbtrary code would be nice?
         # TODO find a way to cache this on the host like with the Unix stuff.
         # Limiter is we don't know how to efficiently upload large files to

--- a/lib/chef/provisioning/convergence_strategy/install_msi.rb
+++ b/lib/chef/provisioning/convergence_strategy/install_msi.rb
@@ -31,10 +31,13 @@ module Provisioning
         # Check for existing chef client.
         version = machine.execute_always('chef-client -v')
 
+        # Don't do install/upgrade if a chef client exists and
+        # no chef version is defined by user configs or
+        # the chef client's version already matches user config
         if version.exitstatus == 0
-          if chef_version and version.stdout.strip =~ /Chef: #{chef_version}([^0-9]|$)/
+          if !chef_version
             return
-          elsif !chef_version
+          elsif version.stdout.strip =~ /Chef: #{chef_version}([^0-9]|$)/
             return
           end
         end

--- a/lib/chef/provisioning/convergence_strategy/install_sh.rb
+++ b/lib/chef/provisioning/convergence_strategy/install_sh.rb
@@ -42,10 +42,13 @@ module Provisioning
         # Check for existing chef client.
         version = machine.execute_always('chef-client -v')
 
+        # Don't do install/upgrade if a chef client exists and
+        # no chef version is defined by user configs or
+        # the chef client's version already matches user config
         if version.exitstatus == 0
-          if chef_version and version.stdout.strip =~ /Chef: #{chef_version}([^0-9]|$)/
+          if !chef_version
             return
-          elsif !chef_version
+          elsif version.stdout.strip =~ /Chef: #{chef_version}([^0-9]|$)/
             return
           end
         end

--- a/lib/chef/provisioning/convergence_strategy/install_sh.rb
+++ b/lib/chef/provisioning/convergence_strategy/install_sh.rb
@@ -48,7 +48,10 @@ module Provisioning
         if version.exitstatus == 0
           if !chef_version
             return
-          elsif version.stdout.strip =~ /Chef: #{chef_version}([^0-9]|$)/
+          # This logic doesn't cover the case for a client with 12.0.1.dev.0 => 12.0.1
+          # so we decided to just use exact version for the time being (see comments in PR 303)
+          #elsif version.stdout.strip =~ /Chef: #{chef_version}([^0-9]|$)/
+          elsif version.stdout.strip =~ /Chef: #{chef_version}$/
             return
           end
         end


### PR DESCRIPTION
Chef installer takes care of upgrade/downgrade automagically!

Please note, that we could definitely improve the error handling if a bad version is passed, as the chef error is pretty vague.