### PR TITLE
Update chef gem to fix version conflict in ChefDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,12 @@ Kitchen
 
 Chef Provisioning also works with Test Kitchen, allowing you to test entire clusters, not just machines!  The repository for the kitchen-metal gem is https://github.com/doubt72/kitchen-metal.
 
+
+Fixing conflict with chef-zero 3.2.1 and ~> 4.0 
+-----------------------------------------------
+
+If you run into the error `Unable to activate cheffish-1.0.0, because chef-zero-3.2.1 conflicts with chef-zero (~> 4.0)` you'll need to update the version of the chef gem included in the ChefDK.  Follow the instructions @ [https://github.com/fnichol/chefdk-update-app](https://github.com/fnichol/chefdk-update-app) and update chef to ~>12.2.1 
+
 Bugs and The Plan
 -----------------
 


### PR DESCRIPTION
This is an update to the readme with instructions on how to fix the version conflict problem with ChefDK 0.4.0 locking chef-zero to 3.2.1 which conflicts with the requirement for version ~4.0 of the gem