### PR TITLE
Install chef-client using Proxy

### DIFF
--- a/lib/chef/provisioning/convergence_strategy/install_sh.rb
+++ b/lib/chef/provisioning/convergence_strategy/install_sh.rb
@@ -64,7 +64,18 @@ module Provisioning
 
         # Install chef client
         # TODO ssh verification of install.sh before running arbtrary code would be nice?
-        @@install_sh_cache[install_sh_url] ||= Net::HTTP.get(URI(install_sh_url))
+        if bootstrap_env.empty?
+          @@install_sh_cache[install_sh_url] ||= Net::HTTP.get(URI(install_sh_url))
+        else
+          proxy_uri = URI.parse(convergence_options[:bootstrap_proxy])
+          chef_uri  = URI.parse(@install_sh_url)
+          proxy     = Net::HTTP::Proxy(proxy_uri.host, proxy_uri.port, proxy_uri.user, proxy_uri.password)
+          req       = Net::HTTP::Get.new(chef_uri.path)
+          script    = proxy.start(chef_uri.host, :use_ssl => proxy_uri.scheme == 'https') do |http|
+            http.request(req)
+          end
+          @@install_sh_cache[install_sh_url] ||= script.body
+        end
         machine.write_file(action_handler, install_sh_path, @@install_sh_cache[install_sh_url], :ensure_dir => true)
         # TODO handle bad version case better
         machine.execute(action_handler, install_sh_command_line)


### PR DESCRIPTION
As a Enterprise User I need to be able to tell chef-provisioning to use my corporate proxy so I can install chef client on my enterprise.

cc/ @jonsmorrow @mfdii @jkeiser @smford22