### PR TITLE
Adding documentation about the private key path

### DIFF
--- a/docs/providers/openstack.md
+++ b/docs/providers/openstack.md
@@ -23,7 +23,8 @@
 :updated     :type => :time   
 :tenant_id   
 :user_id   
-:key_name   
+:key_name
+:key_path
 :fault   
 :config_drive   
 :os_dcf_disk_config   


### PR DESCRIPTION
the fog driver is actually looking for the attribute `machine[:bootstrap_options][:key_path]` in order to load private key from the local machine