### PR TITLE
bumping winrm dependency to 1.3.0

### DIFF
--- a/chef-provisioning.gemspec
+++ b/chef-provisioning.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'net-ssh-gateway', '~> 1.2.0'
   s.add_dependency 'inifile', '~> 2.0'
   s.add_dependency 'cheffish', '~> 1.1'
-  s.add_dependency 'winrm', '~> 1.2.0'
+  s.add_dependency 'winrm', '~> 1.3'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rake'

--- a/lib/chef/provisioning/transport/winrm.rb
+++ b/lib/chef/provisioning/transport/winrm.rb
@@ -86,12 +86,12 @@ $file.Close
         # If you can't pwd within 10 seconds, you can't pwd
         execute('pwd', :timeout => 10)
         true
-      rescue Timeout::Error, Errno::EHOSTUNREACH, Errno::ETIMEDOUT, Errno::ECONNREFUSED, Errno::ECONNRESET, ::WinRM::WinRMHTTPTransportError, ::WinRM::WinRMWebServiceError, ::WinRM::WinRMWSManFault
-        Chef::Log.debug("unavailable: network connection failed or broke: #{$!.inspect}")
-        disconnect
-        false
       rescue ::WinRM::WinRMAuthorizationError
         Chef::Log.debug("unavailable: winrm authentication error: #{$!.inspect} ")
+        disconnect
+        false
+      rescue Timeout::Error, Errno::EHOSTUNREACH, Errno::ETIMEDOUT, Errno::ECONNREFUSED, Errno::ECONNRESET, ::WinRM::WinRMError
+        Chef::Log.debug("unavailable: network connection failed or broke: #{$!.inspect}")
         disconnect
         false
       end


### PR DESCRIPTION
bumping winrm dependency to avoid conflicts when using provisioner as a test-kitchen driver with new test-kitchen winrm functionality