### PR TITLE
Add options[:scp_temp_dir] to set a SCP destination other than /tmp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Chef Provisioning Changelog
 
+- Added support for `options[:scp_temp_dir]` to permit specifying a directory other than `/tmp` to copy files to via SCP.
+
 ## 1.1.1 (4/19/2015)
 
 - Fixed undefined method on nil class error inside setup-convergence ([@tyler-ball][])

--- a/lib/chef/provisioning/transport/ssh.rb
+++ b/lib/chef/provisioning/transport/ssh.rb
@@ -125,7 +125,7 @@ module Provisioning
         execute("mkdir -p #{File.dirname(path)}").error!
         if options[:prefix]
           # Make a tempfile on the other side, upload to that, and sudo mv / chown / etc.
-          remote_tempfile = "#{@scp_temp_dir}#{File.basename(path)}.#{Random.rand(2**32)}"
+          remote_tempfile = "#{@scp_temp_dir}/#{File.basename(path)}.#{Random.rand(2**32)}"
           Chef::Log.debug("Uploading #{local_path} to #{remote_tempfile} on #{username}@#{host}")
           Net::SCP.new(session).upload!(local_path, remote_tempfile)
           begin
@@ -206,7 +206,7 @@ module Provisioning
       def download(path, local_path)
         if options[:prefix]
           # Make a tempfile on the other side, upload to that, and sudo mv / chown / etc.
-          remote_tempfile = "#{@scp_temp_dir}#{File.basename(path)}.#{Random.rand(2**32)}"
+          remote_tempfile = "#{@scp_temp_dir}/#{File.basename(path)}.#{Random.rand(2**32)}"
           Chef::Log.debug("Downloading #{path} from #{remote_tempfile} to #{local_path} on #{username}@#{host}")
           begin
             execute("cp #{path} #{remote_tempfile}").error!


### PR DESCRIPTION
In one of our SSH provisioning scenarios, `/tmp` is not a valid location for `scp` to upload files to on the target machine. I've added a new option, `options[:scp_temp_dir]` which can be used to specify a different destination directory. This solves the problem for us.

````
with_machine_options :transport_options => {
...
  :options => {
    ...
    :scp_temp_dir => '/bootflash', # upload files to /bootflash instead of /tmp
  },
  ...
}
````