### PR TITLE
pwd timed out if prepended with sudo, bumped timeout to 20

### DIFF
--- a/lib/chef/provisioning/transport/ssh.rb
+++ b/lib/chef/provisioning/transport/ssh.rb
@@ -167,8 +167,8 @@ module Provisioning
       end
 
       def available?
-        # If you can't pwd within 10 seconds, you can't pwd
-        execute('pwd', :timeout => 10)
+        # If you can't pwd within 20 seconds, you can't pwd
+        execute('pwd', :timeout => 20)
         true
       rescue Timeout::Error, Errno::EHOSTUNREACH, Errno::ENETUNREACH, Errno::EHOSTDOWN, Errno::ETIMEDOUT, Errno::ECONNREFUSED, Errno::ECONNRESET, Net::SSH::Disconnect
         Chef::Log.debug("#{username}@#{host} unavailable: network connection failed or broke: #{$!.inspect}")


### PR DESCRIPTION
When a new host is created and it doesn't yet have a vaild hostname sudo waits for a dns lookup timeout that takes on average ~18 seconds.  This was causing me strange issues while trying to deploy using the AWS driver.

I was also looking for a way to run sudo without it doing the dns lookup but I was unable to find something to do that.

Once my first chef run is complete and the hostname is set all works well.  Changing this timeout made my deploys more consistent though.