### PR TITLE
with_driver must be specified

### DIFF
--- a/docs/examples/vagrant_linux.rb
+++ b/docs/examples/vagrant_linux.rb
@@ -4,6 +4,8 @@ vagrant_box 'precise64' do
   url 'http://files.vagrantup.com/precise64.box'
 end
 
+with_driver 'vagrant'
+
 with_machine_options :vagrant_options => {
   'vm.box' => 'precise64'
 }


### PR DESCRIPTION
If with_driver is not specified, trying to use this recipe with a machine resource will result in a RuntimeError:

```
Driver not specified for machine mario
```

Where "mario" is from the "simple" recipe example in this repository.