### PR TITLE
expose machine_spec.from_image to allocate_machine

### DIFF
--- a/lib/chef/provider/machine.rb
+++ b/lib/chef/provider/machine.rb
@@ -146,6 +146,7 @@ class Machine < Chef::Provider::LWRPBase
         end
     }
 
+    configs << { from_image: new_resource.from_image } if new_resource.from_image
     configs << new_resource.machine_options if new_resource.machine_options
     configs << driver.config[:machine_options] if driver.config[:machine_options]
     Cheffish::MergedConfig.new(*configs)


### PR DESCRIPTION
Currently `from_image` is added to the `machine_spec` immediately after `allocate_machine`. I'm not sure if that was by design. I can think of scenarios where one would want to know if the machine is being created from an image from allocate_machine. This is possible using this hack:

```ruby
case action_handler
when Chef::Provisioning::AddPrefixActionHandler # From machine_batch
  machines = action_handler.action_handler.provider.new_resource.machines
  this_machine = machines.select { |m| m.name == machine_spec.name}.first
  this_machine.from_image
else # from machine
  action_handler.provider.new_resource.from_image
end
```
This feels a bit evil.

This PR sets the `machine_spec.from_image` in the `machine` `load_current_resource` which also allows the value to be set just once instead of both the `machine` and `machine_batch` resources.