### PR TITLE
Create client.rb only if missing. Fixes #318

### DIFF
--- a/lib/chef/provisioning/convergence_strategy/precreate_chef_objects.rb
+++ b/lib/chef/provisioning/convergence_strategy/precreate_chef_objects.rb
@@ -27,7 +27,9 @@ module Provisioning
 
         # Create client.rb and client.pem on machine
         content = client_rb_content(chef_server_url, machine.node['name'])
-        machine.write_file(action_handler, convergence_options[:client_rb_path], content, :ensure_dir => true)
+        unless machine.file_exists?(convergence_options[:client_rb_path])
+          machine.write_file(action_handler, convergence_options[:client_rb_path], content, :ensure_dir => true)
+        end
       end
 
       def converge(action_handler, machine)


### PR DESCRIPTION
This seems like a straightforward fix for #318. Previously, the `client.rb` file checksum was compared on each `chef-provisioning` run and if it didn't match it was updated. This caused a fight if the node was also running `chef-client` daemon - the daemon might change the client.rb file contents which makes `chef-provisioning` unhappy. I really believe that `chef-provisioning` should only manage the `client.rb` on the first run.