### PR TITLE
use mixlib-install to install from omnitruck

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 gemfile
 gemspec
 
+#gem 'mixlib-install', path: '../mixlib-install'
 #gem 'net-ssh', :path => '../net-ssh'
 #gem 'chef', :path => '../chef'
 #gem 'ohai', :path => '../ohai'

--- a/chef-provisioning.gemspec
+++ b/chef-provisioning.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'inifile', '~> 2.0'
   s.add_dependency 'cheffish', '~> 1.1'
   s.add_dependency 'winrm', '~> 1.3'
+  s.add_dependency "mixlib-install",  "~> 0.4"
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
closes #327, closes #300, closes #38

chef/mixlib-install is extracted from test-kitchen. It supports installing nightlies and prereleases, supports windows properly and doesn't use bash.