### PR TITLE
Upload the PS1 script and run directly

### DIFF
--- a/lib/chef/provisioning/machine/windows_machine.rb
+++ b/lib/chef/provisioning/machine/windows_machine.rb
@@ -75,6 +75,10 @@ EOM
         end
       end
 
+      def system_drive
+        transport.execute('$env:SystemDrive').stdout.strip
+      end
+
       # Set file attributes { :owner, :group, :rights }
 #      def set_attributes(action_handler, path, attributes)
 #      end

--- a/lib/chef/provisioning/transport/winrm.rb
+++ b/lib/chef/provisioning/transport/winrm.rb
@@ -36,8 +36,11 @@ module Provisioning
       def execute(command, execute_options = {})
         output = with_execute_timeout(execute_options) do
           session.set_timeout(execute_timeout(execute_options))
-          session.run_powershell_script(command) do |stdout, stderr|
-            stream_chunk(execute_options, stdout, stderr)
+          block = Proc.new { |stdout, stderr| stream_chunk(execute_options, stdout, stderr) }
+          if execute_options[:raw]
+            session.run_cmd(command, &block)
+          else
+            session.run_powershell_script(command, &block)
           end
         end
         WinRMResult.new(command, execute_options, config, output)


### PR DESCRIPTION
* Introduce the ability to run a cmd directly in winrm, rather than
  through powershell
* Arrange for the output of the install script to be streamed

Fixes #409, Fixes chef/chef-provisioning-aws#284

cc @rancohen1 @tyler-ball (This supercedes #409 and should be more robust)