### PR TITLE
Run our tests in a matrix of Chef client versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,31 @@
 sudo: false
 language: ruby
 rvm:
-- 2.1.2
+  - 2.1.2
+
+gemfile:
+  - chef-client-version.gemfile
+
+env:
+  - CHEF_VERSION=master
+  - CHEF_VERSION=12.4.1
+  # - CHEF_VERSION=12.4.0    # we know 12.4.0 doesn't work and specifically exclude it.
+  - CHEF_VERSION=12.3.0
+  - CHEF_VERSION=12.2.1
+  - CHEF_VERSION=12.1.2
+  - CHEF_VERSION=12.1.1
+  - CHEF_VERSION=12.1.0
+
+matrix:
+  # fast_finish: true
+  allow_failures:
+    - env: CHEF_VERSION=master
+
 script:
+  - bundle install --jobs=3 --retry=3
   - bundle exec rake install
   - bundle exec rake cycle
+
 notifications:
   slack:
     secure: Ueimquh2DjsPZ24PX+yI9a4QzI0rxNInq8xWkIlbhkrhWtdnnZQT4Rk2Bg89gZkHjvp7NZLvHh5hLc39QlYDEycbx3+BdEryEg+33WpdCnShlzQjcMmOvOXBhs6nyOKvIZAjkrcFwfp/4cftk/2dXoE0Za6B3RBOD2yxeHV/nO0=

--- a/bin/generate_driver
+++ b/bin/generate_driver
@@ -105,6 +105,7 @@ file prefix("resource/#{resource_name}.rb") do
   content <<-EOS
 # For details on LWRPs, please see the documentation at http://docs.getchef.com/lwrp.html.
 class Chef::Resource::#{camel_name}ExampleResource < Chef::Resource::LWRPBase
+  self.resource_name = "#{resource_name}"
 end
 EOS
 end

--- a/chef-client-version.gemfile
+++ b/chef-client-version.gemfile
@@ -1,0 +1,17 @@
+source "https://rubygems.org"
+
+always_restrict = "!= 12.4.0"
+chef_version = ENV['CHEF_VERSION']
+
+if chef_version == 'master'
+  puts "Testing chef/chef master"
+  gem 'chef', github: 'chef/chef'
+elsif chef_version
+  puts "Testing Chef version #{chef_version}"
+  gem 'chef', chef_version, always_restrict
+else
+  puts "Testing latest Chef released version #{always_restrict}"
+  gem 'chef', always_restrict
+end
+
+gemspec

--- a/chef-provisioning.gemspec
+++ b/chef-provisioning.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.email = 'jkeiser@chef.io'
   s.homepage = 'http://github.com/chef/chef-provisioning/README.md'
 
-  s.add_dependency 'chef', '>= 11.16.4'
+  s.add_dependency 'chef', '~> 12.1', "!= 12.4.0"  # 12.4.0 is incompatible.
   s.add_dependency 'net-ssh', '~> 2.0'
   s.add_dependency 'net-scp', '~> 1.0'
   s.add_dependency 'net-ssh-gateway', '~> 1.2.0'


### PR DESCRIPTION
Head-of-master fails on `rake install` for no discernible reason, but the specs pass.