### PR TITLE
Specify additional machine_options from the resource attributes

### DIFF
--- a/lib/chef/provider/load_balancer.rb
+++ b/lib/chef/provider/load_balancer.rb
@@ -17,7 +17,7 @@ class Chef
       end
 
       def new_driver
-        @new_driver ||= run_context.chef_metal.driver_for(new_resource.driver)
+        @new_driver ||= run_context.chef_provisioning.driver_for(new_resource.driver)
       end
 
       def chef_managed_entry_store


### PR DESCRIPTION
This is to support https://github.com/chef/chef-provisioning-aws/pull/299

To make tagging cleaner I wanted to enable users to use `aws_tags` as a resource attribute instead of having to specify it in the `machine_options`.  This brings `machine` in line with other aws resources.

If we like this I'll have to expand it to the `load_balancer` resource as well.  The other option is that we continue having users specify `aws_tags` in the `machine_options` until we refactor away driver.rb