### PR TITLE
use platform_specific_path(ohai_hint) on windows

### DIFF
--- a/lib/chef/provisioning/convergence_strategy/precreate_chef_objects.rb
+++ b/lib/chef/provisioning/convergence_strategy/precreate_chef_objects.rb
@@ -127,6 +127,8 @@ module Provisioning
           convergence_options[:ohai_hints].each_pair do |hint, data|
             # The location of the ohai hint
             ohai_hint = "/etc/chef/ohai/hints/#{hint}.json"
+            # It's in a different path on windows
+            ohai_hint = ChefConfig::Config.platform_specific_path(ohai_hint)
             machine.write_file(action_handler, ohai_hint, data.to_json, :ensure_dir => true)
           end
         end

--- a/lib/chef/provisioning/transport/winrm.rb
+++ b/lib/chef/provisioning/transport/winrm.rb
@@ -1,6 +1,7 @@
 require 'chef/provisioning/transport'
 require 'base64'
 require 'timeout'
+require 'winrm'
 
 class Chef
 module Provisioning


### PR DESCRIPTION
There is no '/etc' on windows. Should fix chef/chef-provisioning#433