### PR TITLE
Added missing arguments to call of chef install shell script.

### DIFF
--- a/lib/chef/provisioning/convergence_strategy/install_sh.rb
+++ b/lib/chef/provisioning/convergence_strategy/install_sh.rb
@@ -42,7 +42,7 @@ module Provisioning
         install_command = Mixlib::Install.new(chef_version, false, opts).install_command
         machine.write_file(action_handler, install_sh_path, install_command, :ensure_dir => true)
         machine.set_attributes(action_handler, install_sh_path, :mode => '0755')
-        machine.execute(action_handler, "sh -c #{install_sh_path}")
+        machine.execute(action_handler, "sh -c '#{install_sh_path} #{install_sh_arguments}'")
       end
 
       def converge(action_handler, machine)


### PR DESCRIPTION
While trying to provision a machine using chefdk I wondered why the usual chef-client package was installed instead. The `install_sh_arguments` is not passed to the `install_sh_path` call in https://github.com/chef/chef-provisioning/blob/master/lib/chef/provisioning/convergence_strategy/install_sh.rb#L45 - This PR wraps the call into a string, hence to single quotes inside the double quotes.