### PR TITLE
Fix install_sh_arguments passing after the conversion to mixlib-install

### DIFF
--- a/lib/chef/provisioning/convergence_strategy/install_sh.rb
+++ b/lib/chef/provisioning/convergence_strategy/install_sh.rb
@@ -39,10 +39,14 @@ module Provisioning
           opts["https_proxy"] = convergence_options[:bootstrap_proxy]
         end
 
+        if convergence_options[:install_sh_arguments]
+          opts['install_flags'] = convergence_options[:install_sh_arguments]
+        end
+
         install_command = Mixlib::Install.new(chef_version, false, opts).install_command
         machine.write_file(action_handler, install_sh_path, install_command, :ensure_dir => true)
         machine.set_attributes(action_handler, install_sh_path, :mode => '0755')
-        machine.execute(action_handler, "sh -c '#{install_sh_path} #{install_sh_arguments}'")
+        machine.execute(action_handler, "sh -c #{install_sh_path}")
       end
 
       def converge(action_handler, machine)


### PR DESCRIPTION
The conversion to `mixlib-install` left the passing of `install_sh_arguments` unwired.   This patch properly wires it up, and undoes https://github.com/chef/chef-provisioning/pull/439 which didn't work.