### PR TITLE
deep merge machine options, #455

### DIFF
--- a/lib/chef/resource/machine.rb
+++ b/lib/chef/resource/machine.rb
@@ -98,9 +98,8 @@ class Machine < Chef::Resource::LWRPBase
   end
 
   def add_machine_options(options)
-    @machine_options = Cheffish::MergedConfig.new(options, @machine_options)
+    @machine_options = Chef::Mixin::DeepMerge.hash_only_merge(options, @machine_options)
   end
-
 
   # This is here because provisioning users will probably want to do things like:
   # machine "foo"

--- a/lib/chef/resource/machine.rb
+++ b/lib/chef/resource/machine.rb
@@ -98,7 +98,7 @@ class Machine < Chef::Resource::LWRPBase
   end
 
   def add_machine_options(options)
-    @machine_options = Chef::Mixin::DeepMerge.hash_only_merge(options, @machine_options)
+    @machine_options = Chef::Mixin::DeepMerge.hash_only_merge(@machine_options, options)
   end
 
   # This is here because provisioning users will probably want to do things like:


### PR DESCRIPTION
use deep merge for machine() add_machine_options, addresses bootstrap_options merge failure in #455
