### PR TITLE
Added bootstrap_no_proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ with_machine_options({
     chef_config: "log_level :debug\\n", # String containing additional text to inject into client.rb
     chef_server: "http://my.chef.server/", # TODO could conflict with https://github.com/chef/chef-provisioning#pointing-boxes-at-chef-servers
     bootstrap_proxy: "http://localhost:1234",
+    bootstrap_no_proxy: "localhost, *.example.com, my.chef.server",
     ssl_verify_mode: :verify_peer,
     client_rb_path: "/etc/chef/client.rb", # <- DEFAULT, overwrite if necessary
     client_pem_path: "/etc/chef/client.pem", # <- DEFAULT, overwrite if necessary

--- a/lib/chef/provisioning/convergence_strategy/precreate_chef_objects.rb
+++ b/lib/chef/provisioning/convergence_strategy/precreate_chef_objects.rb
@@ -239,6 +239,11 @@ module Provisioning
             https_proxy #{convergence_options[:bootstrap_proxy].inspect}
           EOM
         end
+        if convergence_options[:bootstrap_no_proxy]
+          content << <<-EOM
+            no_proxy #{convergence_options[:bootstrap_no_proxy].inspect}
+          EOM
+        end
         content.gsub!(/^\s+/, "")
         content << convergence_options[:chef_config] if convergence_options[:chef_config]
         content


### PR DESCRIPTION
As discussed with @irvingpop , this adds the ability to specify the `no_proxy` option in the client.rb file when `convergence_options[:bootstrap_no_proxy]` is set (as a comma-seperated string).

This is useful when an environment needs to connect to some servers via a proxy (ie chef.io to download the chef-client), but others directly (ie internal infrastructure management API).