### PR TITLE
Pinning to mixlib-install 0.7.0 until 1.0 is out

### DIFF
--- a/chef-provisioning.gemspec
+++ b/chef-provisioning.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'inifile', '~> 2.0'
   s.add_dependency 'cheffish', '~> 1.3', '>= 1.3.1'  # 1.3.1 allows 'let' vars in unquoted recipes.
   s.add_dependency 'winrm', '~> 1.3'
-  s.add_dependency "mixlib-install",  "~> 0.6.0"
+  s.add_dependency "mixlib-install",  "~> 0.7.0"
 
   s.add_development_dependency 'chef', '~> 12.1', "!= 12.4.0"  # 12.4.0 is incompatible.
   s.add_development_dependency 'rspec'

--- a/lib/chef/provisioning/convergence_strategy/install_sh.rb
+++ b/lib/chef/provisioning/convergence_strategy/install_sh.rb
@@ -14,7 +14,6 @@ module Provisioning
           :client_pem_path => '/etc/chef/client.pem'
         })
         super(convergence_options, config)
-        @install_sh_url = convergence_options[:install_sh_url] || 'https://www.chef.io/chef/install.sh'
         @install_sh_path = convergence_options[:install_sh_path] || '/tmp/chef-install.sh'
         @chef_version = convergence_options[:chef_version]
         @prerelease = convergence_options[:prerelease]
@@ -25,7 +24,6 @@ module Provisioning
 
       attr_reader :chef_version
       attr_reader :prerelease
-      attr_reader :install_sh_url
       attr_reader :install_sh_path
       attr_reader :install_sh_arguments
       attr_reader :bootstrap_env


### PR DESCRIPTION
This version won't re-install chef if you specify the chef_version convergence option.  Fixes https://github.com/chef/chef-provisioning/issues/428