### PR TITLE
Ensure target directory exists when using write_file with WinRM

### DIFF
--- a/lib/chef/provisioning/transport/winrm.rb
+++ b/lib/chef/provisioning/transport/winrm.rb
@@ -56,6 +56,7 @@ module Provisioning
       end
 
       def write_file(path, content)
+        execute("New-Item -Type Directory -Force -Path #{escape(::File.dirname(path))}").error!
         chunk_size = options[:chunk_size] || 1024
         # TODO if we could marshal this data directly, we wouldn't have to base64 or do this godawful slow stuff :(
         index = 0


### PR DESCRIPTION
This mimics the behavior of the `mkdir -p` line in the SSH transport.