### PR TITLE
Require ResourceBuilder file before monkeypatching to ensure it is already defined

### DIFF
--- a/lib/chef/provisioning/driver.rb
+++ b/lib/chef/provisioning/driver.rb
@@ -311,12 +311,12 @@ end
 
 # In chef-provisioning we don't perform resource cloning
 # This fixes resource cloning when the ResourceBuilder is present
-
+require 'chef/resource_builder' unless defined?(Chef::ResourceBuilder)
 class Chef
   class ResourceBuilder
     if defined?(:prior_resource)
       def prior_resource
-        # NOOP
+        nil
       end
     end
   end


### PR DESCRIPTION
When monkeypatching the ResourceBuilder class we first need to ensure the primary instance is already defined.  Otherwise our monkeypatching becomes the primary instance and the real instance is never defined.

\cc @jkeiser @smith @randomcamel @jaym @btm 