### PR TITLE
Clarify where to put the call to `with_chef_server`

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ with_chef_local_server :chef_repo_path => '~/repo'
 
 `with_chef_local_server` is a generic directive that creates a chef-zero server pointed at the given repository.  nodes, clients, data bags, and all data will be stored here on your provisioner machine if you do this.
 
-You can use `with_chef_server` instead if you want to point at OSS, Hosted or Enterprise Chef, and if you don't specify a Chef server at all, it will use the one you are running chef-client against. Keep in mind when using `with_chef_server` and running `chef-client -z` on your workstation that you will also need to set the client name and signing key for the chef server. If you've already got knife.rb set up, then something like this will correctly create a client for the chef server on instance using your knife.rb configuration:
+You can use `with_chef_server` instead if you want to point at OSS, Hosted or Enterprise Chef, and if you don't specify a Chef server at all, it will use the one you are running chef-client against. Keep in mind when using `with_chef_server` and running `chef-client -z` on your workstation that you will also need to set the client name and signing key for the chef server. If you've already got knife.rb set up, then something like this in the provisioning recipe will correctly create a client for the chef server on instance using your knife.rb configuration:
 
 ```ruby
 with_chef_server "https://chef-server.example.org",


### PR DESCRIPTION
This was somewhat confusing before, seeming like the call to
with_chef_server should be added to the knife.rb. This is to fix #476.