### PR TITLE
Updating to the latest release of net-ssh to consume net-ssh/net-ssh#280

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,5 +13,5 @@ gemspec
 group :development do
 #  gem "berkshelf", github: "berkshelf/berkshelf"
   # TODO we depend on the master branch until chef/chef is released
-  gem "chef", github: "chef/chef", branch: "tball/netssh"
+  gem "chef", github: "chef/chef", branch: "master"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,6 @@ gemspec
 #gem 'chef-zero', :path => '../chef-zero'
 group :development do
 #  gem "berkshelf", github: "berkshelf/berkshelf"
+  # TODO we depend on the master branch until chef/chef is released
+  gem "chef", github: "chef/chef", branch: "tball/netssh"
 end

--- a/chef-provisioning.gemspec
+++ b/chef-provisioning.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.email = 'jkeiser@chef.io'
   s.homepage = 'http://github.com/chef/chef-provisioning/README.md'
 
-  s.add_dependency 'net-ssh', '~> 2.0'
+  s.add_dependency 'net-ssh', '>= 2.9', '< 4.0'
   s.add_dependency 'net-scp', '~> 1.0'
   s.add_dependency 'net-ssh-gateway', '~> 1.2.0'
   s.add_dependency 'inifile', '~> 2.0'

--- a/lib/chef/provisioning/transport/ssh.rb
+++ b/lib/chef/provisioning/transport/ssh.rb
@@ -177,7 +177,7 @@ module Provisioning
         timeout = ssh_options[:timeout] || 10
         execute('pwd', :timeout => timeout)
         true
-      rescue Timeout::Error, Errno::EHOSTUNREACH, Errno::ENETUNREACH, Errno::EHOSTDOWN, Errno::ETIMEDOUT, Errno::ECONNREFUSED, Errno::ECONNRESET, Net::SSH::Disconnect
+      rescue Timeout::Error, Errno::EHOSTUNREACH, Errno::ENETUNREACH, Errno::EHOSTDOWN, Errno::ETIMEDOUT, Errno::ECONNREFUSED, Errno::ECONNRESET, Net::SSH::Disconnect, Net::SSH::ConnectionTimeout
         Chef::Log.debug("#{username}@#{host} unavailable: network connection failed or broke: #{$!.inspect}")
         disconnect
         false
@@ -199,7 +199,7 @@ module Provisioning
             if gateway? then gateway.ssh(host, username, ssh_start_opts)
             else Net::SSH.start(host, username, ssh_start_opts)
             end
-          rescue Timeout::Error
+          rescue Timeout::Error, Net::SSH::ConnectionTimeout
             Chef::Log.debug("Timed out connecting to SSH: #{$!}")
             raise InitialConnectTimeout.new($!)
           end


### PR DESCRIPTION
All the products in the ChefDK are getting updated to 3.0.2