### PR TITLE
WinRM::CommandExecutor support

### DIFF
--- a/lib/chef/provisioning/transport/winrm.rb
+++ b/lib/chef/provisioning/transport/winrm.rb
@@ -37,10 +37,12 @@ module Provisioning
         output = with_execute_timeout(execute_options) do
           session.set_timeout(execute_timeout(execute_options))
           block = Proc.new { |stdout, stderr| stream_chunk(execute_options, stdout, stderr) }
+          executor = ::WinRM::CommandExecutor.new(session)
+          executor.open
           if execute_options[:raw]
-            session.run_cmd(command, &block)
+            executor.run_cmd(command, &block)
           else
-            session.run_powershell_script(command, &block)
+            executor.run_powershell_script(command, &block)
           end
         end
         WinRMResult.new(command, execute_options, config, output)


### PR DESCRIPTION
Should fix #487 though there is probably more to due to bring in support for running via schtask.

#443 and chef/chef-provisioning-aws#324