### PR TITLE
Fix Provisioning with Cheffish 1.x

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -39,11 +39,11 @@ namespace :driver do
   end
 end
 
-require 'github_changelog_generator/task'
-
-GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-  # config.future_release = ChefZero::VERSION
-  config.enhancement_labels = "enhancement,Enhancement,New Feature".split(',')
-  config.bug_labels = "bug,Bug,Improvement,Upstream Bug".split(',')
-  config.exclude_labels = "duplicate,question,invalid,wontfix,no_changelog".split(',')
-end
+# require 'github_changelog_generator/task'
+# 
+# GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+#   # config.future_release = ChefZero::VERSION
+#   config.enhancement_labels = "enhancement,Enhancement,New Feature".split(',')
+#   config.bug_labels = "bug,Bug,Improvement,Upstream Bug".split(',')
+#   config.exclude_labels = "duplicate,question,invalid,wontfix,no_changelog".split(',')
+# end

--- a/lib/chef/provider/machine.rb
+++ b/lib/chef/provider/machine.rb
@@ -175,10 +175,16 @@ class Machine < Chef::Provider::LWRPBase
   end
 
   def load_current_resource
-    node_driver = Chef::Resource::ChefNode.new(new_resource.name, run_context).provider_for_action(:create)
-    node_driver.load_current_resource
-    json = node_driver.new_json
-    json['normal']['chef_provisioning'] = node_driver.current_json['normal']['chef_provisioning']
+    if defined?(Chef::Provider::ChefNode)
+      # Cheffish 1.x
+      node_provider = Chef::Provider::ChefNode.new(new_resource, run_context)
+    else
+      # Cheffish 2.x
+      node_provider = Chef::Resource::ChefNode.action_class.new(new_resource, run_context)
+    end
+    node_provider.load_current_resource
+    json = node_provider.new_json
+    json['normal']['chef_provisioning'] = node_provider.current_json['normal']['chef_provisioning']
     @machine_spec = chef_managed_entry_store.new_entry(:machine, new_resource.name, json)
   end
 


### PR DESCRIPTION
The code used to fix provisioning for Cheffish 2.x broke `with_chef_server` in Cheffish 1.x, which did that by using the `machine` resource as the ChefNode provider's `new_resource` (since they have the same attributes). This reverts us to using the provider instead of the resource to take advantage of that.