### PR TITLE
Retry getting private key without the driver config if its not originally found

### DIFF
--- a/lib/chef/provisioning/driver.rb
+++ b/lib/chef/provisioning/driver.rb
@@ -303,7 +303,7 @@ module Provisioning
     end
 
     def get_private_key(name)
-      Cheffish.get_private_key(name, config)
+      Cheffish.get_private_key(name, config) || Cheffish.get_private_key(name)
     end
   end
 end


### PR DESCRIPTION
I was trying to initialize a fog driver, when I kept running into this issue:

```
    RuntimeError
    ------------
    Server has key name 'openstack', but the corresponding private key was not found locally.  
    Check if the key is in Chef::Config.private_key_paths: /home/bbbco/.chef/keys, /home/bbbco/.ssh
```

Much to my frustration, the key it was looking for were in both of those locations. I traced the issue back to this method, which passes the driver config into the Cheffish module method. If the config doesn't have :private_key_paths set, then it just returns nil, and ultimately the driver fails back up the stack. 

This fix tries to get the private key using the driver config first, and if nothing returned, will try again without the driver config (and Cheffish will just default to pulling its own node's config in).
