### PR TITLE
forcing ssh_options to hash to avoid #delete failing

### DIFF
--- a/lib/chef/provisioning/transport/ssh.rb
+++ b/lib/chef/provisioning/transport/ssh.rb
@@ -39,7 +39,7 @@ module Provisioning
       def initialize(host, username, ssh_options, options, global_config)
         @host = host
         @username = username
-        @ssh_options = ssh_options
+        @ssh_options = ssh_options.to_h
         @options = options
         @config = global_config
         @remote_forwards = ssh_options.delete(:remote_forwards) { Array.new }


### PR DESCRIPTION
The passed-in ssh_options may be a MergedConfig when
the merged configs both contain the same key, such
as `:ssh`:

```
[2] pry(main)> opts1 = { bootstrap_options: { ssh: { username: "foo" } } }
=> {:bootstrap_options=>{:ssh=>{:username=>"foo"}}}
[3] pry(main)> opts2 = { bootstrap_options: { ssh: { password: "monkey" } } }
=> {:bootstrap_options=>{:ssh=>{:password=>"monkey"}}}
[4] pry(main)> machine_options = Cheffish::MergedConfig.new(opts1, opts2)
=> #<Cheffish::MergedConfig:0x007fa84afb0050
 @configs=[{:bootstrap_options=>{:ssh=>{:username=>"foo"}}}, {:bootstrap_options=>{:ssh=>{:password=>"monkey"}}}],
 @merge_arrays={}>
[5] pry(main)> machine_options[:bootstrap_options][:ssh]
=> #<Cheffish::MergedConfig:0x007fa84c580f38 @configs=[{:username=>"foo"}, {:password=>"monkey"}], @merge_arrays={}>
```

Unfortunately, `Cheffish::MergedConfig` has no support
for a `#delete` method, which will cause an exception on this line:

https://github.com/chef/chef-provisioning/blob/master/lib/chef/provisioning/transport/ssh.rb#L45

This change ensures that the ssh_options is a hash before 
doing hash-like things to it.
