### PR TITLE
Allow newer inifile gem

### DIFF
--- a/chef-provisioning.gemspec
+++ b/chef-provisioning.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'net-ssh', '>= 2.9', '< 4.0'
   s.add_dependency 'net-scp', '~> 1.0'
   s.add_dependency 'net-ssh-gateway', '~> 1.2.0'
-  s.add_dependency 'inifile', '~> 2.0'
+  s.add_dependency 'inifile', '>= 2.0.2'
   s.add_dependency 'cheffish', '>= 1.3.1', '< 3.0'  # 1.3.1 allows 'let' vars in unquoted recipes.
   s.add_dependency 'winrm', '~> 1.3'
   s.add_dependency "mixlib-install",  "~> 0.7.0"


### PR DESCRIPTION
Folks I work with need to use https://rubygems.org/gems/akamai-edgegrid.

Based on the releases, no one should be using 2.0.0 or 2.0.1 of inifile, hence the constraint.