### PR TITLE
Fix for issue #537

### DIFF
--- a/lib/chef/provisioning/transport/winrm.rb
+++ b/lib/chef/provisioning/transport/winrm.rb
@@ -57,7 +57,12 @@ module Provisioning
       end
 
       def write_file(path, content)
-        execute("New-Item -Type Directory -Force -Path #{escape(::File.dirname(path))}").error!
+        execute("
+if((Test-Path(#{escape(::File.dirname(path))})) -eq 0)
+{
+  New-Item -Type Directory -Force -Path #{escape(::File.dirname(path))}
+}
+").error!
         chunk_size = options[:chunk_size] || 1024
         # TODO if we could marshal this data directly, we wouldn't have to base64 or do this godawful slow stuff :(
         index = 0


### PR DESCRIPTION
"Files in Machine Resources fail to copy on windows when copied to drive root"

Performs a check that the directory does not exist before creating it.

This has been tested against existing and non existing directories as well as root paths
