### PR TITLE
Allow machine_execute resource to run commands that last longer then 15 minutes

### DIFF
--- a/lib/chef/provider/machine_execute.rb
+++ b/lib/chef/provider/machine_execute.rb
@@ -27,7 +27,8 @@ class MachineExecute < Chef::Provider::LWRPBase
   end
 
   action :run do
-    machine.execute(action_handler, new_resource.command, :stream => new_resource.live_stream)
+    machine.execute(action_handler, new_resource.command, :stream => new_resource.live_stream,
+                                                          :timeout => new_resource.timeout)
   end
 
 end

--- a/lib/chef/resource/machine_execute.rb
+++ b/lib/chef/resource/machine_execute.rb
@@ -18,6 +18,7 @@ class MachineExecute < Chef::Resource::LWRPBase
   default_action :run
 
   attribute :command, :kind_of => String, :name_attribute => true
+  attribute :timeout, :kind_of => Integer, :default => 15*60
   attribute :machine, :kind_of => String
   attribute :live_stream, :kind_of => [TrueClass,FalseClass], :default => false
 


### PR DESCRIPTION
Add :timeout attribute to machine_execute resource that will set :timeout option in Chef::Provisioning::Transport.