### PR TITLE
Use Winrm v2 and let winrm-fs do file uploads

### DIFF
--- a/chef-provisioning.gemspec
+++ b/chef-provisioning.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'net-ssh-gateway', '~> 1.2.0'
   s.add_dependency 'inifile', '>= 2.0.2'
   s.add_dependency 'cheffish', '~> 4.0'
-  s.add_dependency 'winrm', '~> 1.3'
+  s.add_dependency 'winrm-fs', '~> 1.0'
   s.add_dependency "mixlib-install",  "~> 1.0"
 
   s.add_development_dependency 'chef', '~> 12.1', "!= 12.4.0"  # 12.4.0 is incompatible.

--- a/lib/chef/provisioning/convergence_strategy/install_msi.rb
+++ b/lib/chef/provisioning/convergence_strategy/install_msi.rb
@@ -41,8 +41,7 @@ module Provisioning
 
         action_handler.open_stream(machine.node['name']) do |stdout|
           action_handler.open_stream(machine.node['name']) do |stderr|
-            machine.execute(action_handler, "powershell.exe -ExecutionPolicy Unrestricted -NoProfile \"& \"\"#{convergence_options[:install_script_path]}\"\"\"",
-              :raw => true,
+            machine.execute(action_handler, "& \"#{convergence_options[:install_script_path]}\"",
               :stream_stdout => stdout,
               :stream_stderr => stderr)
           end
@@ -54,10 +53,11 @@ module Provisioning
 
         action_handler.open_stream(machine.node['name']) do |stdout|
           action_handler.open_stream(machine.node['name']) do |stderr|
-            command_line = "chef-client"
+            # We just installed chef in this shell so refresh PATH from System.Environment
+            command_line = "$env:path = [System.Environment]::GetEnvironmentVariable('PATH', 'MACHINE');"
+            command_line << "chef-client"
             command_line << " -l #{config[:log_level].to_s}" if config[:log_level]
             machine.execute(action_handler, command_line,
-              :raw => true,
               :stream_stdout => stdout,
               :stream_stderr => stderr,
               :timeout => @chef_client_timeout)


### PR DESCRIPTION
This PR accomplishes 3 things:
* Updates WinRM gem usage to 2.0 API
* Replaces file upload code with wintm-fs (same code used by test-kitchen, inspec and vagrant) with its 1.0 implementation its orders of mafnitude faster the the former implementation and no longer constrained to 8k chunks.
* Use one powershell based shell throughout an entire converge. This is simpler, faster and follows the same approach as test-kitchen.