### PR TITLE
[DO NOT MERGE, for conversation ] winrm elevated

### DIFF
--- a/lib/chef/provisioning/transport/winrm.rb
+++ b/lib/chef/provisioning/transport/winrm.rb
@@ -100,9 +100,23 @@ module Provisioning
 
       def session
         @session ||= begin
-          require 'winrm'
-          ::WinRM::Connection.new(options).shell(:powershell)
-        end
+                       require 'winrm-elevated'
+                       require 'pry-byebug'
+                       #binding.pry
+                       # look for create_with_defaults
+                       #$unless options.nil?
+                       # options = options.merge({
+                       #                           operation_timeout: '600',
+                       #                           receive_timeout: '700'
+                       #                         })
+                       #  options = options.merge({
+                       @options.merge({
+                         operation_timeout: '600',
+                         receive_timeout: '700'
+                       })
+                       #end
+                       ::WinRM::Connection.new(options).shell(:elevated)
+                     end
       end
 
       def file_transporter


### PR DESCRIPTION
exploring connection options for winrm connection timeout

@tyler-ball  poking around with solving that timout connection issue

without elevated we get:

```
  - run '& "C:\chef\install.ps1"' on base-2012r2-2016-10-20[2016-10-20T05:41:56+13:00] INFO: Processing chef_node[base-2012r2-2016-10-20] action create (basic_chef_client::block line 57)
[2016-10-20T05:41:57+13:00] INFO: Converging base-2012r2-2016-10-20 because the resource was updated ...

    [base-2012r2-2016-10-20] The term 'chef-client' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
                             At line:1 char:77
                             + $env:path = [System.Environment]::GetEnvironmentVariable('PATH', 'MACHINE');chef ...
                             +                                                                             ~~~~
                                 + CategoryInfo          : ObjectNotFound: (chef-client:String) [], CommandNotFoundException
                                 + FullyQualifiedErrorId : CommandNotFoundException

```

Just changing to shell(:elevated) seems to make it timeout....
