### PR TITLE
Fixes for chef13 and cheffish5.x/cheffish-13.x

### DIFF
--- a/chef-provisioning.gemspec
+++ b/chef-provisioning.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'net-scp', '~> 1.0'
   s.add_dependency 'net-ssh-gateway', '~> 1.2'
   s.add_dependency 'inifile', '>= 2.0.2'
-  s.add_dependency 'cheffish', '>= 4.0', '< 6.0'
+  s.add_dependency 'cheffish', '>= 4.0', '< 14.0'
   s.add_dependency 'winrm', '~> 2.0'
   s.add_dependency 'winrm-fs', '~> 1.0'
   s.add_dependency 'winrm-elevated', '~> 1.0'

--- a/lib/chef/provisioning/chef_run_data.rb
+++ b/lib/chef/provisioning/chef_run_data.rb
@@ -99,7 +99,7 @@ module Provisioning
       drivers[driver_url] ||= begin
         if driver_url == @current_driver && @current_driver_options
           # Use the driver options if available
-          merged_config = Cheffish::MergedConfig.new({ :driver_options => @current_driver_options }, config)
+          merged_config = Cheffish::MergedConfig.new({ :driver_options => @current_driver_options }, config.to_hash)
           driver = Chef::Provisioning.driver_for_url(driver_url, merged_config)
         else
           driver = Chef::Provisioning.driver_for_url(driver_url, config)

--- a/lib/chef/provisioning/recipe_dsl.rb
+++ b/lib/chef/provisioning/recipe_dsl.rb
@@ -59,7 +59,7 @@ class Chef
       def machine_batch(name = nil, &block)
         name ||= machine_batch_default_name
         recipe = self
-        declare_resource(:machine_batch, name, caller[0]) do
+        declare_resource(:machine_batch, name) do
           from_recipe recipe
           instance_eval(&block)
         end

--- a/lib/chef/resource/machine_batch.rb
+++ b/lib/chef/resource/machine_batch.rb
@@ -38,7 +38,7 @@ class MachineBatch < Chef::Resource::LWRPBase
   end
 
   def machine(name, &block)
-    machines << from_recipe.build_resource(:machine, name, caller[0], &block)
+    machines << from_recipe.build_resource(:machine, name, &block)
   end
 
   def add_machine_options(options)


### PR DESCRIPTION
* driver_for_url needs a to_hash added to its config for the string url case (like used with vsphere, for exmple), since MergedConfig only takes hashes, but config is a mash

* resource creation functions no longer take caller

The first of these is actually required for chef12 with cheffish5 as well, the other two commits are chef-13 compatability