### PR TITLE
hash hash baby.

### DIFF
--- a/lib/chef/provisioning/chef_run_data.rb
+++ b/lib/chef/provisioning/chef_run_data.rb
@@ -99,7 +99,7 @@ module Provisioning
       drivers[driver_url] ||= begin
         if driver_url == @current_driver && @current_driver_options
           # Use the driver options if available
-          merged_config = Cheffish::MergedConfig.new({ :driver_options => @current_driver_options }, config)
+          merged_config = Cheffish::MergedConfig.new({ :driver_options => @current_driver_options }, config.to_hash)
           driver = Chef::Provisioning.driver_for_url(driver_url, merged_config)
         else
           driver = Chef::Provisioning.driver_for_url(driver_url, config)


### PR DESCRIPTION
It seems there is a bug with how the mash is created with more...full
Chef::Config options. This forces the `config` to be a hash to make sure
that it is created correctly for Cheffish 5+.

Signed-off-by: JJ Asghar <jj@chef.io>