### PR TITLE
Putting back in place some development dependencies I removed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,8 @@ gemspec
 #gem 'chef-provisioning-fog', :path => '../chef-provisioning-fog'
 #gem 'chef-provisioning-aws', :path => '../chef-provisioning-aws'
 #gem 'chef-zero', :path => '../chef-zero'
-#gem "berkshelf", github: "berkshelf/berkshelf"
+group :development do
+  # TODO we depend on the master branch until 13 is released and used in the ChefDK
+  gem "ohai", git: "https://github.com/chef/ohai", branch: "master"
+  gem "chef", git: "https://github.com/chef/chef", branch: "master"
+end

--- a/chef-provisioning.gemspec
+++ b/chef-provisioning.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'winrm-elevated', '~> 1.0'
   s.add_dependency "mixlib-install",  ">= 1.0", "< 3.0"
 
-  s.add_development_dependency 'chef', '~> 12.1', "!= 12.4.0"  # 12.4.0 is incompatible.
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'pry'


### PR DESCRIPTION
@lamont-granquist I thought I was being smart, but I think I just did not understand what you were doing in #577 and #568 

Am I correct in thinking that you have loosened these dependencies so they will work with upcoming Chef and ChefDK releases?