### PR TITLE
Fix convergence_options being steamrolled rather than merged

### DIFF
--- a/lib/chef/provisioning/convergence_strategy/install_cached.rb
+++ b/lib/chef/provisioning/convergence_strategy/install_cached.rb
@@ -22,7 +22,7 @@ module Provisioning
       # - :chef_version, :prerelease, :package_cache_path
       # - :package_metadata
       def initialize(convergence_options, config)
-        convergence_options = Cheffish::MergedConfig.new(convergence_options, {
+        convergence_options = Cheffish::MergedConfig.new(convergence_options.to_hash, {
           :client_rb_path => '/etc/chef/client.rb',
           :client_pem_path => '/etc/chef/client.pem'
         })

--- a/lib/chef/provisioning/convergence_strategy/install_msi.rb
+++ b/lib/chef/provisioning/convergence_strategy/install_msi.rb
@@ -21,7 +21,7 @@ module Provisioning
       def setup_convergence(action_handler, machine)
         if !convergence_options.has_key?(:client_rb_path) || !convergence_options.has_key?(:client_pem_path)
           system_drive = machine.system_drive
-          @convergence_options = Cheffish::MergedConfig.new(convergence_options, {
+          @convergence_options = Cheffish::MergedConfig.new(convergence_options.to_hash, {
             :client_rb_path => "#{system_drive}\\chef\\client.rb",
             :client_pem_path => "#{system_drive}\\chef\\client.pem",
             :install_script_path => "#{system_drive}\\chef\\\install.ps1"

--- a/lib/chef/provisioning/convergence_strategy/install_sh.rb
+++ b/lib/chef/provisioning/convergence_strategy/install_sh.rb
@@ -9,7 +9,7 @@ module Provisioning
       @@install_sh_cache = {}
 
       def initialize(convergence_options, config)
-        convergence_options = Cheffish::MergedConfig.new(convergence_options, {
+        convergence_options = Cheffish::MergedConfig.new(convergence_options.to_hash, {
           :client_rb_path => '/etc/chef/client.rb',
           :client_pem_path => '/etc/chef/client.pem'
         })


### PR DESCRIPTION
After upgrading to the latest chef-dk (1.3.43) I was unable to chef-provision windows boxes in AWS.  Found the old open issue https://github.com/chef/chef-provisioning/issues/448 which was similar but I was also seeing this on the :setup action, and the error message is now different thanks to changes to the class since then...but I believe this would likely resolve that issue as well.

I was getting the message "Unable to converge locally via winrm. Local converge is currently only supported with SSH. You may only converge with winrm against a chef-server." It appeared that my `with_chef_server` config as well as my other `convergence_options` were being lost somewhere.

**Partial stack trace:**

```
/opt/chefdk/embedded/lib/ruby/gems/2.3.0/gems/chef-provisioning-2.2.1/lib/chef/provisioning/transport/winrm.rb:93:in `make_url_available_to_remote'
/opt/chefdk/embedded/lib/ruby/gems/2.3.0/gems/chef-provisioning-2.2.1/lib/chef/provisioning/machine/basic_machine.rb:75:in `make_url_available_to_remote'
/opt/chefdk/embedded/lib/ruby/gems/2.3.0/gems/chef-provisioning-2.2.1/lib/chef/provisioning/convergence_strategy/precreate_chef_objects.rb:32:in `setup_convergence'
/opt/chefdk/embedded/lib/ruby/gems/2.3.0/gems/chef-provisioning-2.2.1/lib/chef/provisioning/convergence_strategy/install_msi.rb:37:in `setup_convergence'
/opt/chefdk/embedded/lib/ruby/gems/2.3.0/gems/chef-provisioning-2.2.1/lib/chef/provisioning/machine/basic_machine.rb:17:in `setup_convergence'
/opt/chefdk/embedded/lib/ruby/gems/2.3.0/gems/chef-provisioning-2.2.1/lib/chef/provider/machine.rb:47:in `block in <class:Machine>'
(eval):2:in `block in action_setup'
```

**Debugging:**
You can see below that it's trying to merge a new hash with `convergence_options` which is already of type `Cheffish::MergedConfig`.  This appears to silently fail and instead "steamroll" convergence_options with the hash it's trying to merge in.

```
[21, 30] in /opt/chefdk/embedded/lib/ruby/gems/2.3.0/gems/chef-provisioning-2.2.1/lib/chef/provisioning/convergence_strategy/install_msi.rb
   21:
   22:       def setup_convergence(action_handler, machine)
   23:         if !convergence_options.has_key?(:client_rb_path) || !convergence_options.has_key?(:client_pem_path)
   24:           system_drive = machine.system_drive
   25:           byebug
=> 26:           @convergence_options = Cheffish::MergedConfig.new(convergence_options, {
   27:             :client_rb_path => "#{system_drive}\\chef\\client.rb",
   28:             :client_pem_path => "#{system_drive}\\chef\\client.pem",
   29:             :install_script_path => "#{system_drive}\\chef\\\install.ps1"
   30:           })

# See convergence_options type
(byebug) convergence_options.class
Cheffish::MergedConfig

# Dumping convergence_options values, pre-"merge"
(byebug) puts convergence_options
{"chef_server"=>{"chef_server_url"=>"https://mychefserver/organizations/myorg", "options"=>{"client_name"=>"my_mac", "signing_key_filename"=>"/Users/myusername/.chef/my_mac.pem", "api_version"=>"0"}}, "allow_overwrite_keys"=>nil, "source_key"=>nil, "source_key_path"=>nil, "source_key_pass_phrase"=>nil, "private_key_options"=>nil, "ohai_hints"=>{"ec2"=>""}, "public_key_path"=>nil, "public_key_format"=>nil, "admin"=>nil, "validator"=>nil, "chef_config"=>nil, "ssl_verify_mode"=>:verify_none, "chef_version"=>"12.19.36"}
nil

(byebug) continue
/opt/chefdk/embedded/lib/ruby/gems/2.3.0/gems/cheffish-5.0.1/lib/cheffish/merged_config.rb:6: warning: toplevel constant Mash referenced by Chef::Mash
/opt/chefdk/embedded/lib/ruby/gems/2.3.0/gems/cheffish-5.0.1/lib/cheffish/merged_config.rb:7: warning: toplevel constant Mash referenced by Chef::Mash

[29, 38] in /opt/chefdk/embedded/lib/ruby/gems/2.3.0/gems/chef-provisioning-2.2.1/lib/chef/provisioning/convergence_strategy/install_msi.rb
   29:             :install_script_path => "#{system_drive}\\chef\\\install.ps1"
   30:           })
   31:         end
   32:         byebug
   33:
=> 34:         opts = {"prerelease" => prerelease}
   35:         if convergence_options[:bootstrap_proxy]
   36:           opts["http_proxy"] = convergence_options[:bootstrap_proxy]
   37:           opts["https_proxy"] = convergence_options[:bootstrap_proxy]
   38:         end

# See how convergence_options was replaced rather than merged
(byebug) puts convergence_options
{"client_rb_path"=>"C:\\chef\\client.rb", "client_pem_path"=>"C:\\chef\\client.pem", "install_script_path"=>"C:\\chef\\install.ps1"}
```
**Solution**
Adding the `.to_hash` per my PR fixed the issue.