### PR TITLE
allow newer net-ssh-gateway

### DIFF
--- a/chef-provisioning.gemspec
+++ b/chef-provisioning.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'net-ssh', '>= 2.9', '< 5.0'
   s.add_dependency 'net-scp', '~> 1.0'
-  s.add_dependency 'net-ssh-gateway', '~> 1.2'
+  s.add_dependency 'net-ssh-gateway', '> 1.2', '< 3.0'
   s.add_dependency 'inifile', '>= 2.0.2'
   s.add_dependency 'cheffish', '>= 4.0', '< 14.0'
   s.add_dependency 'winrm', '~> 2.0'


### PR DESCRIPTION
, since other parts of the stack now depend on it, and it works.  causes builds with today's stack to sto being broken!