### PR TITLE
remove normal pessimistic constraint for mixlib install

### DIFF
--- a/chef-provisioning.gemspec
+++ b/chef-provisioning.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'winrm', '~> 2.0'
   s.add_dependency 'winrm-fs', '~> 1.0'
   s.add_dependency 'winrm-elevated', '~> 1.0'
-  s.add_dependency "mixlib-install",  ">= 1.0", "< 3.0"
+  s.add_dependency "mixlib-install",  ">= 1.0"
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
This changes remove the pessimistic constraint for mixlib-install.

Signed-off-by: Patrick Wright <patrick@chef.io>