### PR TITLE
Add an option to never use SSH port forwardin

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ with_machine_options({
     :host_key_alias => "#{instance.id}.AWS", # DEFAULT
     :key_data => nil, # use key from ssh-agent instead of a local file; remember to ssh-add your keys!
     :forward_agent => true, # you may want your ssh-agent to be available on your provisioned machines
+    :never_forward_localhost => false, # This will, if set, disable SSH forwarding if it does not work/make sense in your envirnoment
     :remote_forwards => [
         # Give remote host access to squid proxy on provisioning node
         {:remote_port => 3128, :local_host => 'localhost', :local_port => 3128,},

--- a/lib/chef/provisioning/transport/ssh.rb
+++ b/lib/chef/provisioning/transport/ssh.rb
@@ -43,6 +43,7 @@ module Provisioning
         @options = options
         @config = global_config
         @remote_forwards = ssh_options.delete(:remote_forwards) { Array.new }
+        @never_forward_localhost = ssh_options.delete(:never_forward_localhost)
       end
 
       attr_reader :host
@@ -173,7 +174,9 @@ module Provisioning
 
       def make_url_available_to_remote(local_url)
         uri = URI(local_url)
-        if uri.scheme == 'chefzero' && !ChefZero::SocketlessServerMap.server_on_port(uri.port).server
+        if @never_forward_localhost
+          return uri.to_s
+        elsif uri.scheme == 'chefzero' && !ChefZero::SocketlessServerMap.server_on_port(uri.port).server
           # There is no .server for a socketless, for a socket-d server it would
           # be a WEBrick::HTTPServer object.
           raise 'Cannot forward a socketless Chef Zero server, see https://docs.chef.io/deprecations_local_listen.html for more information'


### PR DESCRIPTION
We have situations where our templates have SSH port forwrding hard disabled - this patch allows the specifying of an SSH option to never even try.  It should alsop help with the "chef_server_url localhost" issue that crops up from time to time.