### PR TITLE
chef_config really should take a hash of options rather than a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ with_machine_options({
     chef_version: "12.4.1",
     prerelease: false,
     chef_client_timeout: 120*60, # Default: 2 hours
-    chef_config: "log_level :debug\\n", # String containing additional text to inject into client.rb
+    chef_config: { :log_level => :debug }, # Hash containing additional options to inject into client.rb, or String containing additional text to inject into client.rb
     chef_server: "http://my.chef.server/", # TODO could conflict with https://github.com/chef/chef-provisioning#pointing-boxes-at-chef-servers
     bootstrap_proxy: "http://localhost:1234",
     bootstrap_no_proxy: "localhost, *.example.com, my.chef.server",

--- a/lib/chef/provisioning/convergence_strategy/precreate_chef_objects.rb
+++ b/lib/chef/provisioning/convergence_strategy/precreate_chef_objects.rb
@@ -228,30 +228,38 @@ module Provisioning
                               :verify_none
                             end
 
-        content = <<-EOM
+        content = <<~EOM
           chef_server_url #{chef_server_url.inspect}
           node_name #{node_name.inspect}
           client_key #{convergence_options[:client_pem_path].inspect}
           ssl_verify_mode #{ssl_verify_mode.to_sym.inspect}
         EOM
         if convergence_options[:bootstrap_proxy]
-          content << <<-EOM
+          content << <<~EOM
             http_proxy #{convergence_options[:bootstrap_proxy].inspect}
             https_proxy #{convergence_options[:bootstrap_proxy].inspect}
           EOM
         end
         if convergence_options[:bootstrap_no_proxy]
-          content << <<-EOM
+          content << <<~EOM
             no_proxy #{convergence_options[:bootstrap_no_proxy].inspect}
           EOM
         end
         if convergence_options[:rubygems_url]
-          content << <<-EOM
+          content << <<~EOM
             rubygems_url #{convergence_options[:rubygems_url].inspect}
           EOM
         end
-        content.gsub!(/^\s+/, "")
-        content << convergence_options[:chef_config] if convergence_options[:chef_config]
+        if convergence_options[:chef_config].is_a?(String)
+          content << convergence_options[:chef_config]
+        elsif convergence_options[:chef_config].is_a?(Hash)
+          convergence_options[:chef_config].each do |option, value|
+            content << <<~EOM
+              #{option.to_s} #{value.inspect}
+            EOM
+          end
+        end
+
         content
       end
     end


### PR DESCRIPTION
This PR make it optionally do so.  Even worked once for me!