### PR TITLE
Add Errno::ECONNABORTED to the list of rescued errors in the available? function

### DIFF
--- a/lib/chef/provisioning/transport/winrm.rb
+++ b/lib/chef/provisioning/transport/winrm.rb
@@ -79,7 +79,7 @@ module Provisioning
         Chef::Log.debug("unavailable: winrm authentication error: #{$!.inspect} ")
         disconnect
         false
-      rescue Timeout::Error, Errno::EHOSTUNREACH, Errno::ETIMEDOUT, Errno::ECONNREFUSED, Errno::ECONNRESET, ::WinRM::WinRMError
+      rescue Timeout::Error, Errno::EHOSTUNREACH, Errno::ETIMEDOUT, Errno::ECONNREFUSED, Errno::ECONNRESET, ::WinRM::WinRMError, Errno::ECONNABORTED
         Chef::Log.debug("unavailable: network connection failed or broke: #{$!.inspect}")
         disconnect
         false


### PR DESCRIPTION
Attempts to attach over winrm using SSL when the SSL endpoint does not
yet exist will result in an ECONNABORTED exception.

Obvious fix.

Fixes #605 