### PR TITLE
Fix machine execute

### DIFF
--- a/chef-provisioning.gemspec
+++ b/chef-provisioning.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'net-scp', '~> 1.0'
   s.add_dependency 'net-ssh-gateway', '> 1.2', '< 3.0'
   s.add_dependency 'inifile', '>= 2.0.2'
-  s.add_dependency 'cheffish', '>= 4.0', '< 14.0'
+  s.add_dependency 'cheffish', '>= 4.0', '< 15.0'
   s.add_dependency 'winrm', '~> 2.0'
   s.add_dependency 'winrm-fs', '~> 1.0'
   s.add_dependency 'winrm-elevated', '~> 1.0'

--- a/lib/chef/provider/machine_execute.rb
+++ b/lib/chef/provider/machine_execute.rb
@@ -5,6 +5,7 @@ require 'chef/provisioning/machine'
 class Chef
 class Provider
 class MachineExecute < Chef::Provider::LWRPBase
+  provides :machine_execute
 
   def action_handler
     @action_handler ||= Chef::Provisioning::ChefProviderActionHandler.new(self)

--- a/lib/chef/provisioning/transport/ssh.rb
+++ b/lib/chef/provisioning/transport/ssh.rb
@@ -43,7 +43,7 @@ module Provisioning
         @options = options
         @config = global_config
         @remote_forwards = ssh_options.delete(:remote_forwards) { Array.new }
-        @never_forward_localhost = ssh_options.delete(:never_forward_localhost) unless ssh_options[:never_forward_localhost]
+        @never_forward_localhost = ssh_options.delete(:never_forward_localhost)
       end
 
       attr_reader :host

--- a/lib/chef/provisioning/transport/ssh.rb
+++ b/lib/chef/provisioning/transport/ssh.rb
@@ -36,14 +36,14 @@ module Provisioning
       # The options are used in
       #   Net::SSH.start(host, username, ssh_options)
 
-      def initialize(host, username, ssh_options, options, global_config)
+      def initialize(host, username, init_ssh_options, options, global_config)
         @host = host
         @username = username
-        @ssh_options = ssh_options
+        @ssh_options = init_ssh_options.clone
         @options = options
         @config = global_config
         @remote_forwards = ssh_options.delete(:remote_forwards) { Array.new }
-        @never_forward_localhost = ssh_options.delete(:never_forward_localhost)
+        @never_forward_localhost = ssh_options.delete(:never_forward_localhost) unless ssh_options[:never_forward_localhost]
       end
 
       attr_reader :host


### PR DESCRIPTION
Machine execute was missing its provides, which is why it wasn't working with all providers, and now doens't work at all with newer chef.  add this back!