### PR TITLE
add ready_only action, to ONLY ready a machine but NEVER allocate it

### DIFF
--- a/lib/chef/provider/machine.rb
+++ b/lib/chef/provider/machine.rb
@@ -41,6 +41,12 @@ class Machine < Chef::Provider::LWRPBase
     machine
   end
 
+  action :ready_only do
+    machine = current_driver.ready_machine(action_handler, machine_spec, current_machine_options)
+    machine_spec.save(action_handler)
+    machine
+  end
+
   action :setup do
     machine = action_ready
     begin

--- a/lib/chef/provider/machine_batch.rb
+++ b/lib/chef/provider/machine_batch.rb
@@ -38,6 +38,10 @@ class MachineBatch < Chef::Provider::LWRPBase
   action :ready do
     with_ready_machines
   end
+  
+  action :ready_only do
+    with_ready_machines_only
+  end
 
   action :setup do
     with_ready_machines do |m|
@@ -110,8 +114,8 @@ class MachineBatch < Chef::Provider::LWRPBase
     end
   end
 
-  def with_ready_machines
-    action_allocate
+  def with_ready_machines(ready_only: false)
+    action_allocate unless ready_only
     parallel_do(by_new_driver) do |driver, specs_and_options|
       driver.ready_machines(action_handler, specs_and_options, parallelizer) do |machine|
         machine.machine_spec.save(action_handler)
@@ -129,6 +133,10 @@ class MachineBatch < Chef::Provider::LWRPBase
         end
       end
     end
+  end
+
+  def with_ready_machines_only
+    with_ready_machines(ready_only: true)
   end
 
   def by_id

--- a/lib/chef/resource/machine.rb
+++ b/lib/chef/resource/machine.rb
@@ -17,7 +17,7 @@ class Machine < Chef::Resource::LWRPBase
     @machine_options = run_context.chef_provisioning.current_machine_options
   end
 
-  actions :allocate, :ready, :setup, :converge, :converge_only, :destroy, :stop
+  actions :allocate, :ready, :ready_only, :setup, :converge, :converge_only, :destroy, :stop
   default_action :converge
 
   # Driver attributes

--- a/lib/chef/resource/machine_batch.rb
+++ b/lib/chef/resource/machine_batch.rb
@@ -15,7 +15,7 @@ class MachineBatch < Chef::Resource::LWRPBase
     @machine_options = run_context.chef_provisioning.current_machine_options
   end
 
-  actions :allocate, :ready, :setup, :converge, :converge_only, :destroy, :stop
+  actions :allocate, :ready, :setup, :converge, :converge_only, :destroy, :stop, :ready_only
   default_action :converge
 
   attribute :machines, :kind_of => [ Array ]


### PR DESCRIPTION
We had an issue where node search on a client was returning garbage, and spawning AWS machines when using chef-provisioning-aws for BAU operations.  To mitigate this, a ready_only action has been added, which will NEVER allocate a machine, just make it ready.  This is a peer to converge_only, and it would make sense to often run these together.