### PR TITLE
Allow net ssh 5

### DIFF
--- a/chef-provisioning.gemspec
+++ b/chef-provisioning.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.license = "Apache-2.0"
   s.required_ruby_version = ">= 2.2.2"
 
-  s.add_dependency 'net-ssh', '>= 2.9', '< 5.0'
+  s.add_dependency 'net-ssh', '>= 2.9', '< 6.0'
   s.add_dependency 'net-scp', '~> 1.0'
   s.add_dependency 'net-ssh-gateway', '> 1.2', '< 3.0'
   s.add_dependency 'inifile', '>= 2.0.2'


### PR DESCRIPTION
Allow version 5 of net-ssh, since it has a bunch of fixes which make newer systems work